### PR TITLE
import numpy and remove warnings that do not appear with matplotlib 1.2.1

### DIFF
--- a/tutorials/Plot-Catalog/plot-catalog.ipynb
+++ b/tutorials/Plot-Catalog/plot-catalog.ipynb
@@ -420,6 +420,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "import numpy as np",
       "tbl['RA'].filled(np.nan)"
      ],
      "language": "python",
@@ -599,20 +600,6 @@
        "prompt_number": 15,
        "text": [
         "<matplotlib.collections.PathCollection at 0x103cf7950>"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stderr",
-       "text": [
-        "WARNING:astropy:RuntimeWarning: invalid value encountered in arcsin\n"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "WARNING: RuntimeWarning: invalid value encountered in arcsin [matplotlib.projections.geo]\n"
        ]
       },
       {


### PR DESCRIPTION
Fix a possible NameError if numpy is not imported and remove two warnings that do not appear using matplotlib 1.2.1.
