### PR TITLE
Get html titles to show up for notebooks (possibly drop metadata files?)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,10 +151,10 @@ def check_ipython_version():
     """
     import IPython
     if IPython.version_info < (1, 2, 0, ''):
-        log.warn('Your version of IPython is  <= 1.1.x, so the html titles on '
-                 'notebooks will come out wrong. Please update IPython if you '
-                 'plan to actually deploy to the web site (possibly to the dev '
-                 'version).')
+        log.warn('WARNING: Your version of IPython is  <= 1.1.x, so the html
+                 'titles on notebooks will come out wrong. Please update '
+                 'IPython if you plan to actually deploy to the web site '
+                 '(possibly to the dev version).')
 
 
 setup(name='astropy-tutorials',


### PR DESCRIPTION
I just noticed something about the HTML of the tutorials that are getting generated: their title are "[]".  I've traced the root cause to this: the `nbconvert` html template gets the title from the 'name' attribute of the `metadata` of the `.ipynb` files, and currently that name is empty for the tutorials.

So the question, then, is how to best populate these.  It could be that `README` should just add as part of the instructions to add a useful name to the metadata. The downside to that is that it keeps real metadata in _two_ places - the `.ipynb` file and the `metadata.cfg` file that lives alongside it.

Two alternative approaches:
- Add code to the build step of `setup.py` that either overwrites `name` in the `.ipynb` with whatever `link_name` is from `metadata.cfg`, or just overwrites the title in the generated html to match `link_name` (although both of those may be a bit hacky). 
- Dispense with `metadata.cfg` and instead just put that metadata in the `.ipynb` file - it would be pretty straightforward to modify `setup.py` to do this, as the `.ipynb` is just a JSON file.

@adrn, what do you think?
