### PR TITLE
Tweaks to Quantity tutorial

### DIFF
--- a/tutorials/Quantities/Quantities.ipynb
+++ b/tutorials/Quantities/Quantities.ipynb
@@ -26,7 +26,7 @@
      "source": [
       "In this tutorial we present some examples showing how astropy's `Quantity` object can make astrophysics calculations easier. The examples include calculating the mass of a galaxy from its velocity dispersion and determining masses of molecular clouds from CO intensity maps. We end with an example of good practices for using quantities in functions you might distribute to other people.\n",
       "\n",
-      "For an in-depth coverage of astropy `Quantities`, see the [astropy documentation section](http://docs.astropy.org/en/stable/units/quantity.html)."
+      "For an in-depth discussion of `Quantity` objects, see the [astropy documentation section](http://docs.astropy.org/en/stable/units/quantity.html)."
      ]
     },
     {


### PR DESCRIPTION
This PR makes a few minor changes to the Quantity tutorial: First, while testing adrn/astropy-tutorials#6 , I noticed one of the links wasn't working... Apparently nbconvert doesn't automatically make "http://..." text into a link, so I just did it explicitly (and changed it to a text link).  

More significantly, it also changes the title.  I think this is just a slightly more "catchy" way of describing it, but if others (esp. @abonaca as the orginal author) prefer the original title, that's fine too and I can remove that part.

Note, @adrn, this conflicts slightly with adrn/astropy-tutorials#6 because it alters the metadata for the tutorial. It's easy to fix, but just worth noting because whichever one is merged second will need a rebase.
