### PR TITLE
Enable viewing of (most) notebookes with Python 3.x

### DIFF
--- a/tutorials/FITS-header/FITS-header.ipynb
+++ b/tutorials/FITS-header/FITS-header.ipynb
@@ -7,7 +7,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:8e988975ce1af1a9c3c8dcb6b30fb5345df782023545c3ddcb0cf58c6ebce148"
+  "signature": "sha256:396649b4c4fd39eacc68f62356450cf0f78c88d5aaded5250eb3c3a8d80e4030"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -108,8 +108,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print type(data)\n",
-      "print header[\"NAXIS\"]"
+      "print(type(data))\n",
+      "print(header[\"NAXIS\"])"
      ],
      "language": "python",
      "metadata": {},

--- a/tutorials/FITS-images/FITS-images.ipynb
+++ b/tutorials/FITS-images/FITS-images.ipynb
@@ -7,7 +7,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:6730dbab487e985094dbfb0c0ef5cf8308a9c1d0578c38bf873c7ed721a48b67"
+  "signature": "sha256:9e029d61f0feea4f4d19511b44579e113ef088bc23c9fcc0a05ebcd3093a8821"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -130,8 +130,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print type(image_data)\n",
-      "print image_data.shape"
+      "print(type(image_data))\n",
+      "print(image_data.shape)"
      ],
      "language": "python",
      "metadata": {},
@@ -174,8 +174,8 @@
      "collapsed": false,
      "input": [
       "image_data = fits.getdata(image_file)\n",
-      "print type(image_data)\n",
-      "print image_data.shape"
+      "print(type(image_data))\n",
+      "print(image_data.shape)"
      ],
      "language": "python",
      "metadata": {},
@@ -214,10 +214,10 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print 'Min:', np.min(image_data)\n",
-      "print 'Max:', np.max(image_data)\n",
-      "print 'Mean:', np.mean(image_data)\n",
-      "print 'Stdev:', np.std(image_data)"
+      "print('Min:', np.min(image_data))\n",
+      "print('Max:', np.max(image_data))\n",
+      "print('Mean:', np.mean(image_data))\n",
+      "print('Stdev:', np.std(image_data))"
      ],
      "language": "python",
      "metadata": {},
@@ -249,7 +249,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print type(image_data.flat)"
+      "print(type(image_data.flat))"
      ],
      "language": "python",
      "metadata": {},

--- a/tutorials/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/FITS-tables/FITS-tables.ipynb
@@ -7,7 +7,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:3460b1474fd246437874a4dc87edfcaf0db23d025a712e58e9b764acfebcca4d"
+  "signature": "sha256:9e0497be4b203e31064ce5428d54a3390ac6ecfb4de53d0c6262c2a17ecbdf4f"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -136,7 +136,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print pha_list[1].columns"
+      "print(pha_list[1].columns)"
      ],
      "language": "python",
      "metadata": {},

--- a/tutorials/Plot-Catalog/plot-catalog.ipynb
+++ b/tutorials/Plot-Catalog/plot-catalog.ipynb
@@ -7,7 +7,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:35165ed415be544e141be609b6b3a438c46a455f00808a1cdda35af3042a373f"
+  "signature": "sha256:a6948119e622634bad34bb4d1b7bcbb59e84cab95025724098127104a63cc42c"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -250,7 +250,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "print tbl['RA']"
+      "print(tbl['RA'])"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
Just fixed a few print statements so that notebooks run with Python 3.x.

The Quantities tutorial still fails, however, due to an issue with scalar conversion:

```
ERROR:astropy:TypeError: Only dimensionless scalar quantities can be converted to Python scalars
ERROR: TypeError: Only dimensionless scalar quantities can be converted to Python scalars [astropy.units.quantity]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-7694f196ce41> in <module>()
----> 1 sigma_scalar = math.sqrt(np.sum((v - np.mean(v))**2) / np.size(v))

/usr/lib/python3.4/site-packages/astropy/units/quantity.py in __float__(self)
    719     def __float__(self):
    720         if not self.isscalar or not self.unit.is_unity():
--> 721             raise TypeError('Only dimensionless scalar quantities can be '
    722                             'converted to Python scalars')
    723         else:

TypeError: Only dimensionless scalar quantities can be converted to Python scalars
```
