### PR TITLE
Add show/hide button for tracebacks 

### DIFF
--- a/templates/astropy.tpl
+++ b/templates/astropy.tpl
@@ -40,7 +40,6 @@
         $(this).parent().children('pre').toggle();
         $(this).parent().parent().children('.prompt').toggle();
         $(this).parent().parent().children('.prompt').toggle();
-        //$(this).parent().parent().children('.prompt').show();
     });
 
     $('.output_pyerr pre').hide();


### PR DESCRIPTION
This is maybe not what you had in mind, but it's a quick-fix and has the added value of letting the user see the full traceback if they want to.

Here's a demo:
http://adrn.github.io/astropy-tutorials/Quantities.html
