### PR TITLE
Increase contrast and switch default font for tutorials

### DIFF
--- a/templates/matplotlibrc
+++ b/templates/matplotlibrc
@@ -202,6 +202,7 @@ axes.edgecolor      : black   # axes edge color
 axes.linewidth      : 1        # edge linewidth
 axes.grid           : True     # display grid or not
 axes.titlesize      : x-large  # fontsize of the axes title
+axes.labelweight     : bold
 axes.labelsize      : large    # fontsize of the x any y labels
 axes.labelcolor     : black
 axes.axisbelow      : True     # whether axis gridlines and ticks are below

--- a/templates/matplotlibrc
+++ b/templates/matplotlibrc
@@ -103,7 +103,7 @@ patch.antialiased      : True    # render patches in antialised (no jaggies)
 # The font.size property is the default font size for text, given in pts.
 # 12pt is the standard value.
 #
-font.family          : monospace
+font.family          : sans-serif
 #font.style          : normal
 #font.variant        : normal
 #font.weight         : medium
@@ -115,7 +115,7 @@ font.family          : monospace
 # small, medium, large, x-large, xx-large, larger, or smaller
 font.size           : 12.0
 # font.serif          : Bitstream Vera Serif, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
-#font.sans-serif     : Bitstream Vera Sans, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+font.sans-serif     : Arial, Helvetica, Bitstream Vera Sans, Lucida Grande, Verdana, Geneva, Lucid, Avant Garde, sans-serif
 #font.cursive        : Apple Chancery, Textile, Zapf Chancery, Sand, cursive
 #font.fantasy        : Comic Sans MS, Chicago, Charcoal, Impact, Western, fantasy
 font.monospace      : Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
@@ -197,13 +197,13 @@ font.monospace      : Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, T
 # default fontsizes for ticklabels, and so on.  See
 # http://matplotlib.sourceforge.net/api/axes_api.html#module-matplotlib.axes
 #axes.hold           : True    # whether to clear the axes by default on
-axes.facecolor      : eeeeee   # axes background color
-axes.edgecolor      : bcbcbc   # axes edge color
+axes.facecolor      : ffffff   # axes background color
+axes.edgecolor      : black   # axes edge color
 axes.linewidth      : 1        # edge linewidth
 axes.grid           : True     # display grid or not
 axes.titlesize      : x-large  # fontsize of the axes title
 axes.labelsize      : large    # fontsize of the x any y labels
-axes.labelcolor     : 555555
+axes.labelcolor     : black
 axes.axisbelow      : True     # whether axis gridlines and ticks are below
                                # the axes elements (lines, text, etc)
 #axes.formatter.limits : -7, 7 # use scientific notation if log10
@@ -237,7 +237,7 @@ xtick.major.size     : 0      # major tick size in points
 xtick.minor.size     : 0      # minor tick size in points
 xtick.major.pad      : 6      # distance to major tick label in points
 xtick.minor.pad      : 6      # distance to the minor tick label in points
-xtick.color          : 555555      # color of the tick labels
+xtick.color          : black      # color of the tick labels
 #xtick.labelsize      : medium # fontsize of the tick labels
 xtick.direction      : in     # direction: in or out
 
@@ -245,7 +245,7 @@ ytick.major.size     : 0      # major tick size in points
 ytick.minor.size     : 0      # minor tick size in points
 ytick.major.pad      : 6      # distance to major tick label in points
 ytick.minor.pad      : 6      # distance to the minor tick label in points
-ytick.color          : 555555      # color of the tick labels
+ytick.color          : black      # color of the tick labels
 #ytick.labelsize      : medium # fontsize of the tick labels
 ytick.direction      : in     # direction: in or out
 
@@ -259,7 +259,7 @@ ytick.direction      : in     # direction: in or out
 legend.fancybox      : True  # if True, use a rounded box for the
                                # legend, else a rectangle
 #legend.isaxes        : True
-#legend.numpoints     : 2      # the number of points in the legend line
+legend.numpoints      : 1      # the number of points in the legend line
 #legend.fontsize      : large
 #legend.pad           : 0.0    # deprecated; the fractional whitespace inside the legend border
 #legend.borderpad     : 0.5    # border whitspace in fontsize units
@@ -275,8 +275,8 @@ legend.fancybox      : True  # if True, use a rounded box for the
 # See http://matplotlib.sourceforge.net/api/figure_api.html#matplotlib.figure.Figure
 figure.figsize   : 8, 6    # figure size in inches
 # figure.dpi       : 150      # figure dots per inch
-figure.facecolor : 0.85    # figure facecolor; 0.75 is scalar gray
-figure.edgecolor : 0.50   # figure edgecolor
+figure.facecolor : 1.00    # figure facecolor; 0.75 is scalar gray
+figure.edgecolor : 0.0   # figure edgecolor
 
 # The figure subplot parameters.  All dimensions are fraction of the
 # figure width or height


### PR DESCRIPTION
This PR increases the contrast in the default matplotlibrc used in tutorials, and switches back to a more modern-looking font (resolves #66). Of course such things are subjective, but I feel strongly that the current style emphasizes aesthetics (nice, soft-looking) over legibility, particularly for anyone with less-than-perfect vision.

Old style
![old_plot](https://cloud.githubusercontent.com/assets/3639698/4937545/52416858-65c4-11e4-9bae-5ea2a8a6057b.png)
New style
![new_plot](https://cloud.githubusercontent.com/assets/3639698/4937546/53c2be84-65c4-11e4-9ceb-f7296618bcd0.png)

