### PR TITLE
remove unneeded np.where in FITS-tables

### DIFF
--- a/tutorials/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/FITS-tables/FITS-tables.ipynb
@@ -3,12 +3,12 @@
   "astropy-tutorials": {
    "author": "Lia R. Corrales <lia@astro.columbia.edu>",
    "date": "January 2014",
+   "description": "astropy.utils.data to download the file, astropy.io.fits to open and view the file, matplotlib for making both 1D and 2D histograms of the data.",
    "link_name": "Viewing and manipulating data from FITS tables",
    "name": "",
-   "published": true,
-   "description" : "astropy.utils.data to download the file, astropy.io.fits to open and view the file, matplotlib for making both 1D and 2D histograms of the data."
+   "published": true
   },
-  "signature": "sha256:9e0497be4b203e31064ce5428d54a3390ac6ecfb4de53d0c6262c2a17ecbdf4f"
+  "signature": "sha256:7800e75113478b755d491aa16c6da8a119f59471f1a6dec69981d6d99ed3f92d"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -204,14 +204,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "First, I isolate the zeroth order events using np.where"
+      "First, I create a boolean mask to isolate the zeroth order events"
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "i_zero = np.where(pha_data['tg_m'] == 0)[0]"
+      "i_zero = pha_data['tg_m'] == 0"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
While showing some of the tutorials to some people, I noticed in the FITS-tables tutorial that there's a use of `np.where` that's unnecessary.  That is, a boolean mask will work just fine.

I find this is a common mistake people make transitioning from IDL, so I think it's much better if we avoid using ``np.where`` wherever possible.  So this change just removes the ``np.where`` call.

Is that ok with you @adrn and @eblur (I think you wrote this originally, right @eblur)?