### PR TITLE
Added Disqus Comments to astropy.tpl (Issue 50)

### DIFF
--- a/prepare_deploy.py
+++ b/prepare_deploy.py
@@ -135,8 +135,8 @@ def convert_notebooks(selected_nb_re=None):
 
         with open(html_filename, 'wb') as f:
             html_file_data = html_file_data.decode("utf-8")
-            html_file_data = html_file_data.replace("{title}",
-                                nb['metadata']['astropy-tutorials']['link_name'])
+            html_file_data = html_file_data.replace("{title}",nb['metadata']['astropy-tutorials']['link_name'])
+            html_file_data = html_file_data.replace("{pageurl}","{}.html".format(cleanbase))
             f.write(html_file_data.encode("utf8"))
 
         index_listing = dict()

--- a/templates/astropy.tpl
+++ b/templates/astropy.tpl
@@ -26,9 +26,31 @@
     </nav>
 
     {{ super() }}
-
+	
+	<!--Disqus Comment Section -->
+	
+	<div id="disqus_thread"></div>
+	<script type="text/javascript">
+		/* * * CONFIGURATION VARIABLES * * */
+		var disqus_shortname = '<forum shortname>'; //required <forum shortname> with short name of astropy  
+		var disqus_identifier= '{pageurl}';
+		var disqus_url = 'http://www.astropy.org/astropy-tutorials/{pageurl}';
+		/* * * DON'T EDIT BELOW THIS LINE * * */
+		(function() {
+			var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+			dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+			(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+		})();
+		(function () {
+			var s = document.createElement('script'); s.async = true;
+			s.type = 'text/javascript';
+			s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+			(document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
+		}());
+	<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+	
+	<!--End of comments section-->
 </div>
-
 <!-- This javascript hides tracebacks, but inserts a button to
      let the user toggle showing the full traceback. -->
 <script type='text/javascript'>


### PR DESCRIPTION
Now each tutorial can have a Disqus comment section at the end of the
page!
Only the <forum shortname> variable has to added when the astropy
developers register their site on Disqus

prepare_deploy modification simply allows us to have comments for each
page separated based on the name of the page.