### PR TITLE
Add questions/exercises to tutorials

### DIFF
--- a/tutorials/FITS-header/FITS-header.ipynb
+++ b/tutorials/FITS-header/FITS-header.ipynb
@@ -3,12 +3,12 @@
   "astropy-tutorials": {
    "author": "Adrian M. Price-Whelan <adrn@astro.columbia.edu>",
    "date": "July 2013",
+   "description": "Demonstrates how to read in, edit a FITS header, and then write it back out to disk using astropy.io.fits.",
    "link_name": "Editing a FITS header",
    "name": "",
-   "published": true,
-   "description" : "Demonstrates how to read in, edit a FITS header, and then write it back out to disk using astropy.io.fits."
+   "published": true
   },
-  "signature": "sha256:396649b4c4fd39eacc68f62356450cf0f78c88d5aaded5250eb3c3a8d80e4030"
+  "signature": "sha256:cf2d708df4d0fc7ef4323fb110d8ea45860df205fa6ce40acbebecf1819821eb"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -204,6 +204,35 @@
      "input": [
       "fits.writeto('output_file.fits', data, header, clobber=True)"
      ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercise"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Read in the file you just wrote, and add three header keywords:\n",
+      "\n",
+      "1. 'RA' for the Right Ascension of M31\n",
+      "2. 'DEC' for the Declination of M31\n",
+      "3. 'RADECSRC' with text indicating where you found the RA/Dec (web URL, textbook name, your photographic memory, etc.).\n",
+      "\n",
+      "then write the updated header back out to a new file. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
      "language": "python",
      "metadata": {},
      "outputs": []

--- a/tutorials/FITS-images/FITS-images.ipynb
+++ b/tutorials/FITS-images/FITS-images.ipynb
@@ -8,7 +8,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:c3e6e77f5998aaa1a32bf8fd6a508615004110687b627d7f8dfcaa9b59a6fbcc"
+  "signature": "sha256:192ee736cce2ddffa26e398414e46e7e86754ff8a48a191ccf3434e6b2ea963d"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -446,8 +446,23 @@
      "level": 2,
      "metadata": {},
      "source": [
-      "Exercise"
+      "Exercises"
      ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Determine the mean, median, and standard deviation of a part of the stacked M13 image where there is *not* light from M13.  Use those statistics with a sum over the part of the image that includes M13 to estimate the total light in this image from M13."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",

--- a/tutorials/FITS-images/FITS-images.ipynb
+++ b/tutorials/FITS-images/FITS-images.ipynb
@@ -3,12 +3,12 @@
   "astropy-tutorials": {
    "author": "Lia R. Corrales <lia@astro.columbia.edu>",
    "date": "January 2014",
+   "description": "Demonstrates use of astropy.utils.data to download data; astropy.io.fits to open the file; matplotlib to view the image with different color scales and stretches and to make histrograms. Also includes method for simple image stacking.",
    "link_name": "Viewing and manipulating FITS images",
    "name": "",
-   "published": true,
-   "description" : "Demonstrates use of astropy.utils.data to download data; astropy.io.fits to open the file; matplotlib to view the image with different color scales and stretches and to make histrograms. Also includes method for simple image stacking."
+   "published": true
   },
-  "signature": "sha256:9e029d61f0feea4f4d19511b44579e113ef088bc23c9fcc0a05ebcd3093a8821"
+  "signature": "sha256:c3e6e77f5998aaa1a32bf8fd6a508615004110687b627d7f8dfcaa9b59a6fbcc"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -437,6 +437,46 @@
       "hdu = fits.PrimaryHDU(final_image)\n",
       "hdu.writeto(outfile, clobber=True)"
      ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercise"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Show the image of the Horsehead Nebula, but in to units of *surface brightness* (magnitudes per square arcsecond).\n",
+      "(Hint: the *physical* size of the image is 15x15 arcminutes.)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Now write out the image you just created, preserving the header the original image had, but add a keyword 'UNITS' with the value 'mag per sq arcsec'.\n",
+      "(Hint: you may need to read the [astropy.io.fits](http://docs.astropy.org/en/stable/io/fits/index.html) documentation if you're not sure how to include both the header and the data)"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
      "language": "python",
      "metadata": {},
      "outputs": []

--- a/tutorials/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/FITS-tables/FITS-tables.ipynb
@@ -8,7 +8,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:7800e75113478b755d491aa16c6da8a119f59471f1a6dec69981d6d99ed3f92d"
+  "signature": "sha256:a70c090b1d7a9465e61834c7995c5ccfb99827bcab5fda45ee037c39b8f16b73"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -303,6 +303,59 @@
      "input": [
       "pha_list.close()"
      ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercises"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Make a scatter plot of the same data you histogrammed above.  The [plt.scatter](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.scatter) function is your friend for this.  Why might you want to use this instead of hist2d?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Try the same with the [plt.hexbin](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hexbin) plotting function. Which do you think looks better for this kind of data?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Try making the same, but without sub-selecting on `'i_zero'`.  Which plots help you better understand the data now?  What if you try `'x'` and `'y'` instead of `'tg_r'` and `'tg_d'`?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
      "language": "python",
      "metadata": {},
      "outputs": []

--- a/tutorials/Plot-Catalog/plot-catalog.ipynb
+++ b/tutorials/Plot-Catalog/plot-catalog.ipynb
@@ -8,7 +8,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:6b0d3d16c9d2808ee91ca16dddd6b9ef8e50cb97065b588e8c8256c89e1fc8e6"
+  "signature": "sha256:d8377959a9a80bb857cffd95a033224627c9005df5668385ca7518acb38f2bec"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -418,6 +418,44 @@
      "input": [
       "fig.savefig(\"map.pdf\")"
      ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercises"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Make the map figures as just above, but color the points by the `'Kmag'` column of the table."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Try making the maps again, but with each of the following projections: 'aitoff', 'hammer', 'lambert', and `None` (which is the same as not giving any projection).  Do any of them make the data seem easier to understand?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
      "language": "python",
      "metadata": {},
      "outputs": []

--- a/tutorials/Quantities/Quantities.ipynb
+++ b/tutorials/Quantities/Quantities.ipynb
@@ -8,7 +8,7 @@
    "name": "",
    "published": true
   },
-  "signature": "sha256:fbad6a2b4e71ad46fdc619e7fcdc1ba92947bc4f6cbeda547c35274edca4e46d"
+  "signature": "sha256:38ee8db3d37d4a8736448b719739ab2e2cb961a302b20c696136b60bf1c27051"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -369,6 +369,61 @@
      "input": [
       "np.log10(M)"
      ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercises"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Use `Quantity` and Kepler's law in the form given below to determine the (circular) orbital speed of the Earth around the sun in km/s. You should not have to look up an constants or conversion factors to do this calculation - it's all in `astropy.units` and `astropy.constants`.\n",
+      "\n",
+      "$$v = \\sqrt{\\frac{G M_{\\odot}}{r}}$$"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "There's a much easier way to figure out the velocity of the Earth using just two units or quantities.  Do that and then compare to the Kepler's law answer (the easiest way is probably to compute the percentage difference, if any)."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "(Completely optional, but a good way to convince yourself of the value of Quantity:) Do the above calculations by hand - you can use a calculator (or python just for its arithmatic) but look up all the appropriate conversion factors and use paper-and-pencil approaches for keeping track of them all.  Which one took longer?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
      "language": "python",
      "metadata": {},
      "outputs": []
@@ -858,6 +913,44 @@
     },
     {
      "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercises"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The astro material was pretty heavy on that one, so lets focus on some associated statistics using `Quantity`'s array capabililities. Compute the median and mean of the `data` with the ``np.mean`` and ``np.median`` functions.  Why are their values so different?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Similarly, compute the standard deviation and variance (if you don't know the relevant functions, look it up in the numpy docs or just type np.<tab> and a code cell).  Do they have the units you expect?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
      "level": 3,
      "metadata": {},
      "source": [
@@ -974,6 +1067,29 @@
      "source": [
       "The funding agency is impressed at the resolution you achieved, and your instrument is saved.  You now go on to win the Nobel Prize due to discoveries the instrument makes.  And it was all because you used `Quantity` as the input of code you shared."
      ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 2,
+     "metadata": {},
+     "source": [
+      "Exercise"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Write a function that computes the Keplerian velocity you worked out in section 1 (using `Quantity` input and outputs, of course), but allowing for an arbitrary mass and orbital radius.  Try it with some reasonable numbers for satellites orbiting the Earth, a moon of Jupiter, or an extrasolar planet.  Feel free to use wikipedia or similar for the masses and distances.  "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
     }
    ],
    "metadata": {}


### PR DESCRIPTION
Recently I've had the opportunity to teach a few classes/workshops around Astropy, and the tutorials have been great for this purpose.  

However, most are lacking in one important aspect as active learning tools: they are tutorials that lack prompts for the person taking the tutorial to interact!  The exception is the UVES tutorial, which @hamogu and @migueldvb put a lot of work into to include "exercises".  Taking a page from that tutorial, this PR adds exercises to all of the other tutorials.

I hate to be a pain about this, but I think this should probably be merged before other PRs that might conflict, because this touches a lot of stuff so merging might be quite a bit more problematic for this one...

cc @adrn @kelle  @astrofrog