### PR TITLE
Add travis build to check that notebooks run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+os:
+    - linux
+
+env:
+    global:
+        - NUMPY_VERSION=1.9
+        - PYTHON_VERSION=2.7
+
+install:
+    - source .travis/setup_environment.sh
+
+script:
+    - python prepare_deploy.py run
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     global:
         - NUMPY_VERSION=1.9
         - PYTHON_VERSION=2.7
+        - ASTROPY_VERSION=1.0.2
 
 install:
     - source .travis/setup_environment.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ install:
 
 script:
     - python prepare_deploy.py run
-

--- a/.travis/setup_dependencies.sh
+++ b/.travis/setup_dependencies.sh
@@ -9,7 +9,7 @@ conda install --yes numpy=$NUMPY_VERSION
 
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.
-export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION astropy=$ASTROPY_VERSION"
 
 # CORE DEPENDENCIES
 $CONDA_INSTALL pytest Cython jinja2 psutil

--- a/.travis/setup_dependencies.sh
+++ b/.travis/setup_dependencies.sh
@@ -15,7 +15,7 @@ export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VE
 $CONDA_INSTALL pytest Cython jinja2 psutil
 
 # TUTORIALS DEPENDENCIES
-$CONDA_INSTALL ipython ipython-notebook
+$CONDA_INSTALL ipython ipython-notebook runipy
 
 # OPTIONAL DEPENDENCIES
 $CONDA_INSTALL scipy h5py matplotlib pyyaml

--- a/.travis/setup_dependencies.sh
+++ b/.travis/setup_dependencies.sh
@@ -11,8 +11,11 @@ conda install --yes numpy=$NUMPY_VERSION
 # versions are always explicitly specified.
 export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION astropy=$ASTROPY_VERSION"
 
-# CORE DEPENDENCIES
+# ASTROPY CORE DEPENDENCIES
 $CONDA_INSTALL pytest Cython jinja2 psutil
+
+# TUTORIALS DEPENDENCIES
+$CONDA_INSTALL ipython
 
 # OPTIONAL DEPENDENCIES
 $CONDA_INSTALL scipy h5py matplotlib pyyaml

--- a/.travis/setup_dependencies.sh
+++ b/.travis/setup_dependencies.sh
@@ -15,7 +15,7 @@ export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VE
 $CONDA_INSTALL pytest Cython jinja2 psutil
 
 # TUTORIALS DEPENDENCIES
-$CONDA_INSTALL ipython
+$CONDA_INSTALL ipython ipython-notebook
 
 # OPTIONAL DEPENDENCIES
 $CONDA_INSTALL scipy h5py matplotlib pyyaml

--- a/.travis/setup_dependencies.sh
+++ b/.travis/setup_dependencies.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# CONDA
+conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
+source activate test
+
+# NUMPY
+conda install --yes numpy=$NUMPY_VERSION
+
+# Now set up shortcut to conda install command to make sure the Python and Numpy
+# versions are always explicitly specified.
+export CONDA_INSTALL="conda install --yes python=$PYTHON_VERSION numpy=$NUMPY_VERSION"
+
+# CORE DEPENDENCIES
+$CONDA_INSTALL pytest Cython jinja2 psutil
+
+# OPTIONAL DEPENDENCIES
+$CONDA_INSTALL scipy h5py matplotlib pyyaml
+pip install beautifulsoup4

--- a/.travis/setup_environment.sh
+++ b/.travis/setup_environment.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install conda
+wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b
+export PATH=/home/travis/miniconda/bin:$PATH
+conda update --yes conda
+
+# Install Python dependencies
+source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies.sh


### PR DESCRIPTION
This adds the necessary travis config files to have travis check that the notebooks actually run properly using `python prepare_deploy.py run`.

@eteq does this look right?