### PR TITLE
Updating .travis to reflect recent miniconda path changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
 os:
     - linux
 

--- a/.travis/setup_environment.sh
+++ b/.travis/setup_environment.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 # Install conda
-wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/home/travis/miniconda/bin:$PATH
-conda update --yes conda
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a
 
 # Install Python dependencies
 source "$( dirname "${BASH_SOURCE[0]}" )"/setup_dependencies.sh


### PR DESCRIPTION
In case there'll be tutorial hacking at #dotastro, travis should be able to be run.

Also opted in the container based travis from the legacy.