### PR TITLE
Auto deploy machinery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,18 @@ env:
         - NUMPY_VERSION=1.9
         - PYTHON_VERSION=2.7
         - ASTROPY_VERSION=1.0.2
+        - GH_REF: github.com/astropy/astropy-tutorials.git
+        - secure: "NBZlEg//sDYvJikqXESLsx/WA1Nj7fAH2mJfI8ZVMnolvyjJuLdEMxxEYFP8t6U/iieSSrgUkgP94yy5Oq6iJRjj7ThGCdcjgvgWTQCzoQgEVDc5SzdJGyGs30VC+8t7GTobzMe086HX16SJRvsIumqXdmRcJjAdMCyhMUxLoUg="
 
 install:
     - source .travis/setup_environment.sh
 
 script:
     - python prepare_deploy.py run
+
+deploy:
+    provider: script
+    script: ./travis_deploy
+    on:
+        repo: astropy/astropy-tutorials
+        branch: master

--- a/deploy
+++ b/deploy
@@ -117,7 +117,13 @@ then
         done
 
         echo "Pushing to '$GH_PAGESBRANCH' on remote '$GH_REMOTE'"
-        git push -f $GH_REMOTE $GH_PAGESBRANCH
+        if [ "$INTERACTIVE" = true ] ; then
+            git push -f $GH_REMOTE $GH_PAGESBRANCH
+        else
+            # we do this with nothing to stdout because otherwise it might reveal secret tokens
+            git push -f --quiet $GH_REMOTE $GH_PAGESBRANCH >/dev/null 2>&1
+            echo "Silent push finished."
+        fi
 
         git checkout -f $CURRENT_BRANCH_NAME
         git clean -f

--- a/deploy
+++ b/deploy
@@ -2,20 +2,38 @@
 
 # this conditional assignment means you can do things like:
 # GH_REMOTE=myremote ./deploy
-# to set these to something othere than the default
+# to set these to something other than the default
+
+# branches and remote for pushing to github
 : ${GH_PAGESBRANCH=gh-pages}
 : ${GH_REMOTE=origin}
 
-# get current git branch name - should throw an error if in a detached state
-current_branch_name="$(git symbolic-ref --short HEAD)"
+# if not interactive, automatically "yes" things but don't show anything
+: ${INTERACTIVE=true}
+: ${CURRENT_BRANCH_NAME="$(git symbolic-ref --quiet --short HEAD)"}
+
+if [ -z "$CURRENT_BRANCH_NAME" ]; then 
+    echo "Could not determine current branch.  Cannot continue with deployment." 
+    exit 1
+fi
 
 giveup_message () {
     echo "\n"
     echo "You're now in an orphaned test deploy branch."
     echo "To get back to normal you can run the following:"
-    echo "    git checkout -f $current_branch_name"
+    echo "    git checkout -f $CURRENT_BRANCH_NAME"
     echo "    git clean -f"
     echo "    git branch -D $GH_PAGESBRANCH" 
+}
+
+promptifinteractive () {
+    # first argument is message, second is non-interactive answer, all others passed to read
+    if [ "$INTERACTIVE" = true ] ; then
+        read -p "$1" -r "${@:3}" 
+    else
+        echo $1 $2
+        REPLY=$2
+    fi
 }
 
 echo "*****************************************************************"
@@ -26,7 +44,7 @@ echo
 echo "Make sure you have no uncommitted changes in your current branch"
 echo "as these may be overwritten!"
 echo
-read -p "Are you sure you want to do this? [y/N] " -n 1 -r
+promptifinteractive "Are you sure you want to do this? [y/N] " y -n 1
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
@@ -73,7 +91,7 @@ then
     git add css
     git commit -m "Generated from sources"
 
-    read -p "Would you like to preview the rendered HTML? [y/N] " -n 1 -r
+    promptifinteractive "Would you like to preview the rendered HTML? [y/N] " N -n 1
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo
         echo
@@ -82,13 +100,13 @@ then
         echo
     fi
 
-    read -p "Are you sure you want to push to the remote branch '$GH_PAGESBRANCH' on the remote '$GH_REMOTE'? [y/N] " -n 1 -r
+    promptifinteractive "Are you sure you want to push to the remote branch '$GH_PAGESBRANCH' on the remote '$GH_REMOTE'? [y/N] " y -n 1
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo
         git ls-remote --exit-code $GH_REMOTE > /dev/null 2> /dev/null
         while [[ $? != 0 ]]
         do
-            read -p "Could not communicate with remote '$GH_REMOTE'.  Enter an alternate remote name (or 'quit' to give up):" -r
+            promptifinteractive "Could not communicate with remote '$GH_REMOTE'.  Enter an alternate remote name (or 'quit' to give up):" quit
             if [[ $REPLY = "quit" ]]; then
                 giveup_message
                 exit  
@@ -101,7 +119,7 @@ then
         echo "Pushing to '$GH_PAGESBRANCH' on remote '$GH_REMOTE'"
         git push -f $GH_REMOTE $GH_PAGESBRANCH
 
-        git checkout -f $current_branch_name
+        git checkout -f $CURRENT_BRANCH_NAME
         git clean -f
         git branch -D $GH_PAGESBRANCH
     else

--- a/travis_deploy
+++ b/travis_deploy
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# The key element here is using ``travis encrypt GH_TOKEN=<github personal token>``
+# and then adding the resulting secure key/value pair to .travis.yml
+
+echo "Adding deployment remote"
+git remote add deploy "https://${GH_TOKEN}@${GH_REF}"
+
+export CURRENT_BRANCH_NAME="$(git rev-parse HEAD)"
+export INTERACTIVE=false 
+export GH_REMOTE=deploy
+./deploy

--- a/travis_deploy
+++ b/travis_deploy
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # The key element here is using ``travis encrypt GH_TOKEN=<github personal token>``
-# and then adding the resulting secure key/value pair to .travis.yml
+# and then adding the resulting secure key/value pair to .travis.yml .  For security,
+# probably best to use an account that only has access to this specific repo, not 
+# someone's personal token with general access to all of their stuff.
 
 echo "Adding deployment remote"
 git remote add deploy "https://${GH_TOKEN}@${GH_REF}"

--- a/travis_deploy
+++ b/travis_deploy
@@ -11,4 +11,5 @@ git remote add deploy "https://${GH_TOKEN}@${GH_REF}"
 export CURRENT_BRANCH_NAME="$(git rev-parse HEAD)"
 export INTERACTIVE=false 
 export GH_REMOTE=deploy
+export GH_PAGESBRANCH="test-gh-pages"  # remove this to get deployment on the "real branch"
 ./deploy


### PR DESCRIPTION
This should close #93 by finally setting it up so that merging a PR into master auto-deploys to github pages.  

The main idea is that this modifys the ``deploy`` script to allow non-interactive use, as well as the @astropy-bot account as a user that has the appropriate access privileges along with a travis-encrypted access token. 

The awkward thing is that we can't test it really until merging, as it's specifically *not* supposed to work until merged into master.  If it helps any, though, you can see the results of this by looking at https://github.com/eteq/astropy-tutorials/tree/gh-pages, which was made by the build you see at https://travis-ci.org/eteq/astropy-tutorials/builds/94067132 .  This should be basically the same, except with new tokens and such as relevant for the real astropy-tutorials repo.  (Also, a bit more security that should completely hide the secret token).

cc @adrn @astrofrog