### PR TITLE
Remove footnote from coordinates tutorial

### DIFF
--- a/tutorials/notebooks/coordinates/coordinates.ipynb
+++ b/tutorials/notebooks/coordinates/coordinates.ipynb
@@ -114,7 +114,7 @@
    "source": [
     "If the object you're interested in is in [SESAME](http://cdsweb.u-strasbg.fr/cgi-bin/Sesame), you can also look it up directly from its name using the `SkyCoord.from_name()` class method<sup>1</sup>. Note that this requires an internet connection.  It's safe to skip if you don't have one, because we defined it above explicitly.\n",
     "\n",
-    "<sub> <sup>1</sup>If you don't know what a class method is, think of it like an alternative constructor for a `SkyCoord` object -- calling `SkyCoord.from_name()` with a name gives you a new `SkyCoord` object. For more detailed background on what class methods are and when they're useful, see [this page](https://julien.danjou.info/blog/2013/guide-python-static-class-abstract-methods).</sub>"
+    "*If you don't know what a class method is, think of it like an alternative constructor for a `SkyCoord` object -- calling `SkyCoord.from_name()` with a name gives you a new `SkyCoord` object. For more detailed background on what class methods are and when they're useful, see [this page](https://julien.danjou.info/blog/2013/guide-python-static-class-abstract-methods).*"
    ]
   },
   {
@@ -912,7 +912,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There was some raw HTML in a markdown cell that doesn't get rendered properly when converted to RST. I just make the footnote text italic instead.

I intended to also fix the links (i.e. #180) but can't figure out a good solution. See discussion in the issue.