### PR TITLE
DON't USE - see patch-2 ###Update FITS-images.ipynb

### DIFF
--- a/tutorials/notebooks/FITS-images/FITS-images.ipynb
+++ b/tutorials/notebooks/FITS-images/FITS-images.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_file = download_file('http://data.astropy.org/tutorials/FITS-images/HorseHead.fits', cache=True )"
+    "image_file = download_file('image_file = download_file('https://astropy.stsci.edu/data/tutorials/FITS-images/HorseHead.fits', cache=True)', cache=True )"
    ]
   },
   {


### PR DESCRIPTION
DON"t USE - see patch-2
#####
Updated the link to the HorseHead FITS image  to
'https://astropy.stsci.edu/data/tutorials/FITS-images/HorseHead.fits'