### PR TITLE
Add In/Out markers to generated cells

### DIFF
--- a/tutorials/_static/custom.css
+++ b/tutorials/_static/custom.css
@@ -8,3 +8,11 @@ div.body {
 div.body p {
     font-size: 15px;
 }
+
+span.inputnumrole {
+    color: #303F9F
+}
+
+span.outputnumrole {
+    color: #D84315
+}

--- a/tutorials/astropy.tpl
+++ b/tutorials/astropy.tpl
@@ -21,9 +21,16 @@
 {% endblock %}
 
 {% block in_prompt %}
+
+*In[{{  cell['execution_count'] }}]:*
+
+
 {% endblock in_prompt %}
 
 {% block output_prompt %}
+
+*Out[{{  cell['execution_count'] }}]:*
+
 {% endblock output_prompt %}
 
 {% block input %}

--- a/tutorials/astropy.tpl
+++ b/tutorials/astropy.tpl
@@ -32,7 +32,7 @@
 
 {% block output_prompt %}
 
-:outputnumrole:`Out[{{  cell['execution_count'] }}]:``
+:outputnumrole:`Out[{{  cell['execution_count'] }}]:`
 
 {% endblock output_prompt %}
 

--- a/tutorials/astropy.tpl
+++ b/tutorials/astropy.tpl
@@ -17,19 +17,22 @@
 .. |binder{{ nb_name }}| image:: http://mybinder.org/badge.svg
    :target: https://beta.mybinder.org/v2/gh/astropy/astropy-tutorials/master?filepath=/tutorials/notebooks/{{ nb_name }}/{{ nb_name }}.ipynb
 
+.. role:: inputnumrole
+.. role:: outputnumrole
+
 .. _{{nb_name}}:
 {% endblock %}
 
 {% block in_prompt %}
 
-*In[{{  cell['execution_count'] }}]:*
+:inputnumrole:`In[{{  cell['execution_count'] }}]:`
 
 
 {% endblock in_prompt %}
 
 {% block output_prompt %}
 
-*Out[{{  cell['execution_count'] }}]:*
+:outputnumrole:`Out[{{  cell['execution_count'] }}]:``
 
 {% endblock output_prompt %}
 


### PR DESCRIPTION
This closes #188 by making a surprisingly simple change to the templates.

This isn't *quite* what I think we wanted, because the In/Out text is *above* the cell instead of to the left of it like a notebook.  But I think it's close enough because it makes the distinction much clearer.

Here's what things end up looking like after this PR:
![image](https://user-images.githubusercontent.com/346587/37136926-a898f118-2271-11e8-8517-c1070138614f.png)

