### PR TITLE
Update tutorials to use new image files

### DIFF
--- a/tutorials/notebooks/synthetic-images/synthetic-images.ipynb
+++ b/tutorials/notebooks/synthetic-images/synthetic-images.ipynb
@@ -46,9 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from astropy.utils.data import download_file\n",
@@ -83,7 +81,7 @@
    "outputs": [],
    "source": [
     "file_i = download_file(\n",
-    "    'https://astropy.stsci.edu/data/tutorials/synthetic-images/synchrotron_i_lobe_0700_150MHz.fits', \n",
+    "    'http://data.astropy.org/tutorials/synthetic-images/synchrotron_i_lobe_0700_150MHz_sm.fits', \n",
     "    cache=True)\n",
     "hdulist = fits.open(file_i)\n",
     "hdulist.info()\n",
@@ -107,7 +105,7 @@
    "source": [
     "print(hdu.data.max())\n",
     "print(hdu.data.min())\n",
-    "plt.hist(np.log10(hdu.data.flatten()), range=(-3, 2), bins=100 )"
+    "plt.hist(np.log10(hdu.data.flatten()), range=(-3, 2), bins=100);"
    ]
   },
   {
@@ -142,9 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# distance to the object\n",
@@ -184,9 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w = WCS(naxis=2)\n",
@@ -215,9 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "wcs_header = w.to_header()\n",
@@ -282,17 +274,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# assume our telescope has 1 arcsecond resolution\n",
-    "telescope_resolution=1*u.arcsecond\n",
+    "telescope_resolution = 1*u.arcsecond\n",
     "\n",
     "# calculate the sigma in pixels. \n",
     "# since cdelt is in degrees, we use _.to('deg')\n",
-    "sigma=telescope_resolution.to('deg')/cdelt2"
+    "sigma = telescope_resolution.to('deg')/cdelt2"
    ]
   },
   {
@@ -306,7 +296,7 @@
     "psf = Gaussian2DKernel(sigma)\n",
     "\n",
     "# let's take a look:\n",
-    "plt.imshow(psf)"
+    "plt.imshow(psf.array.value)"
    ]
   },
   {
@@ -343,7 +333,7 @@
     "lorentzian_psf /= np.sum(lorentzian_psf)\n",
     "\n",
     "# let's take a look again:\n",
-    "plt.imshow(lorentzian_psf, interpolation='none')"
+    "plt.imshow(lorentzian_psf.value, interpolation='none')"
    ]
   },
   {
@@ -363,9 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "convolved_image = convolve_fft(hdu.data, psf, boundary='wrap')"
@@ -374,9 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Put a psf at the corner of the image\n",
@@ -423,11 +409,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_q = download_file('http://www.astro.wisc.edu/~ychen/MHD_Jet/fits_dtau_005c/synchrotron_q_lobe_0700_150MHz.fits', )\n",
+    "hdulist.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_q = download_file(\n",
+    "    'http://data.astropy.org/tutorials/synthetic-images/synchrotron_q_lobe_0700_150MHz_sm.fits', \n",
+    "    cache=True)\n",
     "hdulist = fits.open(file_q)\n",
     "hdu_q = hdulist['NN_EMISSIVITY_Q_LOBE_150.0MHZ']\n",
     "\n",
-    "file_u = download_file('http://www.astro.wisc.edu/~ychen/MHD_Jet/fits_dtau_005c/synchrotron_u_lobe_0700_150MHz.fits', )\n",
+    "file_u = download_file(\n",
+    "    'http://data.astropy.org/tutorials/synthetic-images/synchrotron_u_lobe_0700_150MHz_sm.fits', \n",
+    "    cache=True)\n",
     "hdulist = fits.open(file_u)\n",
     "hdu_u = hdulist['NN_EMISSIVITY_U_LOBE_150.0MHZ']\n",
     "\n",
@@ -450,9 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "wcs = WCS(hdu.header)\n",
@@ -488,9 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# First, we plot the background image\n",
@@ -503,7 +498,7 @@
     "yy0, yy1 = i_plot.get_ylim()\n",
     "\n",
     "# binning factor\n",
-    "factor = [64, 64]\n",
+    "factor = [64, 66]\n",
     "\n",
     "# re-binned number of points in each axis\n",
     "nx_new = convolved_image.shape[1] // factor[0]\n",
@@ -557,9 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -580,7 +573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*This should only get merged once astropy/astropy-data#48 is merged!*

This updates the new tutorials to download data files from the data.astropy.org repo. Those files are significantly smaller than the originals: I cut out sections of the images to make the files smaller and make the downloads more manageable. They still require downloading >100MB of data...