### PR TITLE
Try circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,21 +16,22 @@ pip-run: &pip-install
     pip install -q -r pip-requirements.txt
     pip install astropy_helpers sphinx
 
-add_ssh_keys: &add_ssh_keys
-    add_ssh_keys:
-      fingerprints:
-        - 32:53:df:4a:53:71:25:8b:73:42:71:c8:57:8a:3f:f7
-
 jobs:
+  deploy-job:
+    steps:
+
+
   build:
     docker:
       - image: circleci/python:3.6
 
     steps:
       - checkout
+      - add_ssh_keys: # add GitHub SSH keys
+          fingerprints:
+            - 32:53:df:4a:53:71:25:8b:73:42:71:c8:57:8a:3f:f7
       - run: *apt-install # run the apt install defined above
       - run: *pip-install # run the pip install defined above
-      - run: *add_ssh_keys # add GitHub SSH keys
 
       # - restore_cache: # Need cache for all tutorial data!
       #     keys: sample-data-v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,7 @@ version: 2
 apt-run: &apt-install
   name: Install apt packages
   command: |
-    sudo apt update
-    sudo apt install build-essential
+    apt-get install build-essential
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ version: 2
 apt-run: &apt-install
   name: Install apt packages
   command: |
+    apt-get update
     apt-get install build-essential
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Push to RTD branch
           command: |
-            bash circleci/rtd-push.sh
+            bash .circleci/rtd-push.sh
 
       # - save_cache: # Specify what paths to cache
       #     key: sample-data-v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/_build/html/index.html"; echo $DOCS_URL
 
-      # - save_cache: # specify what paths to cache
+      # - save_cache: # Specify what paths to cache
       #     key: sample-data-v1
       #     paths:
       #       - ~/sunpy/data/sample_data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ pip-run: &pip-install
     python3 -m venv venv
     . venv/bin/activate
     pip install -q -r pip-requirements.txt
+    pip install sphinx
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 # Python CircleCI 2.0 configuration file
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 version: 2
+
+apt-run: &apt-install
+  name: Install apt packages
+  command: |
+    sudo apt update
+    sudo apt install build-essential
+
 jobs:
   build:
     docker:
@@ -8,6 +15,7 @@ jobs:
 
     steps:
       - checkout
+      - run: *apt-install # run the apt install defined above
 
       # - restore_cache: # Need cache for all tutorial data!
       #     keys: sample-data-v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,6 @@ pip-run: &pip-install
     pip install -q -r pip-requirements.txt
     pip install astropy_helpers sphinx
 
-jobs:
-  deploy-job:
-    steps:
-
-
   build:
     docker:
       - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ pip-run: &pip-install
     pip install -q -r pip-requirements.txt
     pip install astropy_helpers sphinx
 
+jobs:
+
   build:
     docker:
       - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run:
           name: Build documentation
           command: |
+            . venv/bin/activate
             make html
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ pip-run: &pip-install
     pip install -q -r pip-requirements.txt
     pip install astropy_helpers sphinx
 
+add_ssh_keys: &add_ssh_keys
+    add_ssh_keys:
+      fingerprints:
+        - 32:53:df:4a:53:71:25:8b:73:42:71:c8:57:8a:3f:f7
+
 jobs:
   build:
     docker:
@@ -25,6 +30,7 @@ jobs:
       - checkout
       - run: *apt-install # run the apt install defined above
       - run: *pip-install # run the pip install defined above
+      - run: *add_ssh_keys # add GitHub SSH keys
 
       # - restore_cache: # Need cache for all tutorial data!
       #     keys: sample-data-v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Build documentation
           command: |
-            python setup.py build_docs -w 2> /dev/null
+            python setup.py build_docs -w
 
       - store_artifacts:
           path: docs/_build/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,27 +5,28 @@ version: 2
 apt-run: &apt-install
   name: Install apt packages
   command: |
-    apt-get update
-    apt-get install build-essential
+    sudo apt-get update
+    sudo apt-get install build-essential
+
+pip-run: &pip-install
+  name: Install Python dependencies
+  command: |
+    python3 -m venv venv
+    . venv/bin/activate
+    pip install -q -r pip-requirements.txt
 
 jobs:
   build:
     docker:
-      - image: continuumio/miniconda3
+      - image: circleci/python:3.6
 
     steps:
       - checkout
       - run: *apt-install # run the apt install defined above
+      - run: *pip-install # run the pip install defined above
 
       # - restore_cache: # Need cache for all tutorial data!
       #     keys: sample-data-v1
-
-      - run:
-          name: Conda setup
-          command: |
-            conda config --set always_yes yes --set changeps1 no
-            conda env update --file=environment.yml
-            pip install git+https://github.com/jupyter/nbconvert
 
       - run:
           name: Build documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           path: build/html
 
       - run:
-          name: Built documentation is available at:
+          name: Built documentation is available at
           command: |
             DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/build/html/index.html"; echo $DOCS_URL
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,14 @@ jobs:
           path: build/html
 
       - run:
-          name: "Built documentation is available at:"
+          name: Built documentation is available at:
           command: |
-            DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/_build/html/index.html"; echo $DOCS_URL
+            DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/build/html/index.html"; echo $DOCS_URL
+
+      - run:
+          name: Push to RTD branch
+          command: |
+            bash circleci/rtd-push.sh
 
       # - save_cache: # Specify what paths to cache
       #     key: sample-data-v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,12 @@ jobs:
           command: |
             conda config --set always_yes yes --set changeps1 no
             conda env update --file=environment.yml
+            pip install git+https://github.com/jupyter/nbconvert
 
       - run:
           name: Build documentation
           command: |
-            python setup.py build_docs -w
+            make html
 
       - store_artifacts:
           path: docs/_build/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             make html
 
       - store_artifacts:
-          path: docs/_build/html
+          path: build/html
 
       - run:
           name: "Built documentation is available at:"
@@ -47,3 +47,7 @@ jobs:
       #     key: sample-data-v1
       #     paths:
       #       - ~/sunpy/data/sample_data
+
+notify:
+  webhooks:
+    - url: https://giles.cadair.com/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ apt-run: &apt-install
   name: Install apt packages
   command: |
     sudo apt-get update
-    sudo apt-get install build-essential
+    sudo apt-get install build-essential pandoc
 
 pip-run: &pip-install
   name: Install Python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ pip-run: &pip-install
     python3 -m venv venv
     . venv/bin/activate
     pip install -q -r pip-requirements.txt
-    pip install sphinx
+    pip install astropy_helpers sphinx
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Python CircleCI 2.0 configuration file
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      - image: continuumio/miniconda3
+
+    steps:
+      - checkout
+
+      # - restore_cache: # Need cache for all tutorial data!
+      #     keys: sample-data-v1
+
+      - run:
+          name: Conda setup
+          command: |
+            conda config --set always_yes yes --set changeps1 no
+            conda env update --file=environment.yml
+
+      - run:
+          name: Build documentation
+          command: |
+            python setup.py build_docs -w 2> /dev/null
+
+      - store_artifacts:
+          path: docs/_build/html
+
+      - run:
+          name: "Built documentation is available at:"
+          command: |
+            DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/_build/html/index.html"; echo $DOCS_URL
+
+      # - save_cache: # specify what paths to cache
+      #     key: sample-data-v1
+      #     paths:
+      #       - ~/sunpy/data/sample_data

--- a/.circleci/rtd-push.sh
+++ b/.circleci/rtd-push.sh
@@ -1,3 +1,15 @@
+#!/bin/bash -eux
+
+# if [ -z "${GIT_USER_NAME}" ]; then
+#   echo "Please set an env var GIT_USER_NAME"
+#   exit 1
+# fi
+#
+# if [ -z "${GIT_USER_EMAIL}" ]; then
+#   echo "Please set an env var GIT_USER_EMAIL"
+#   exit 1
+# fi
+
 if [[ ! -z $CIRCLE_PULL_REQUEST ]] ; then
     # git checkout --orphan rst
     # git add -f tutorials/rst-tutorials/*

--- a/.circleci/rtd-push.sh
+++ b/.circleci/rtd-push.sh
@@ -1,0 +1,9 @@
+if [[ ! -z $CIRCLE_PULL_REQUEST ]] ; then
+    # git checkout --orphan rst
+    # git add -f tutorials/rst-tutorials/*
+    # git -c user.name='travis' -c user.email='travis' commit -m "now with RST"
+    # git push -q -f https://adrn:$GITHUB_API_KEY@github.com/astropy/astropy-tutorials rst;
+    echo "Not a pull request: pushing RST files to `rst` branch!"
+else
+    echo "This is a pull request: not pushing RST files."
+fi

--- a/.circleci/rtd-push.sh
+++ b/.circleci/rtd-push.sh
@@ -10,12 +10,14 @@
 #   exit 1
 # fi
 
-if [[ ! -z $CIRCLE_PULL_REQUEST ]] ; then
-    # git checkout --orphan rst
-    # git add -f tutorials/rst-tutorials/*
-    # git -c user.name='travis' -c user.email='travis' commit -m "now with RST"
-    # git push -q -f https://adrn:$GITHUB_API_KEY@github.com/astropy/astropy-tutorials rst;
-    echo "Not a pull request: pushing RST files to `rst` branch!"
+if [[ -z $CIRCLE_PULL_REQUEST ]] ; then
+    git checkout --orphan rst
+    git add -f tutorials/rst-tutorials/*
+    git -c user.name='circle' -c user.email='circle' commit -m "now with RST"
+    git remote add origin git@github.com:astropy/astropy-tutorials.git
+    git push -q -f origin rst
+    echo "Not a pull request: pushing RST files to rst branch."
 else
+    echo $CIRCLE_PULL_REQUEST
     echo "This is a pull request: not pushing RST files."
 fi

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -5,3 +5,8 @@ matplotlib==2.0.2
 numpy==1.13.1
 jupyter==1.0
 scipy=0.19
+notebook=5.0
+aplpy
+spectral-cube
+reproject
+git+https://github.com/jupyter/nbconvert

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -4,8 +4,8 @@ astroquery==0.3.7
 matplotlib==2.0.2
 numpy==1.13.1
 jupyter==1.0
-scipy=0.19
-notebook=5.0
+scipy==0.19
+notebook==5.0
 aplpy
 spectral-cube
 reproject

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -41,6 +41,10 @@ class NBTutorialsConverter(object):
         logger.info('Processing notebook {0} (in {1})'.format(fn,
                                                               self.path_only))
 
+        # the RST file
+        self._rst_path = path.join(self.output_path,
+                                   '{0}.rst'.format(self.nb_name))
+
         if kernel_name is None:
             self.kernel_name = ExecutePreprocessor.kernel_name.default_value
         else:
@@ -106,6 +110,12 @@ class NBTutorialsConverter(object):
         if not path.exists(self._executed_nb_path):
             raise IOError("Executed notebook file doesn't exist! Expected: {0}"
                           .format(self._executed_nb_path))
+
+        if path.exists(self._rst_path) and not self.overwrite:
+            logger.debug("RST version of notebook already exists at {0}. Use "
+                         "overwrite=True or --overwrite (at cmd line) to re-run"
+                         .format(self._rst_path))
+            return self._rst_path
 
         # Initialize the resources dict - see:
         # https://github.com/jupyter/nbconvert/blob/master/nbconvert/nbconvertapp.py#L327


### PR DESCRIPTION
After a conversation with @cadair, he convinced me that we might be able to solve our build issues by running the tutorial build on CircleCI and then pushing the documentation from there to either readthedocs or github pages. The advantage of building on a CI service is that we can cache data files, which is what causes our timeouts and headaches on RTD right now. This is a PR to test out the CircleCI build - *do not merge* yet!