### PR TITLE
Astroquery should be strictly pinned

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.6
   - IPython=6.1.0
   - astropy=3
-  - astroquery=0.3.7
+  - astroquery>=0.3.7
   - matplotlib=2.0.2
   - numpy=1.14
   - scipy=1.0 # needed for coordinates cross-matching

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.6
   - IPython=6.1.0
   - astropy=3
-  - astroquery=0.3.7
+  - astroquery>=0.3.7
   - matplotlib=2.0.2
   - numpy=1.14
   - scipy=1.0 # needed for coordinates cross-matching

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,6 +1,6 @@
 IPython==6.1.0
 astropy==3
-astroquery==0.3.7
+astroquery>=0.3.7
 matplotlib==2.0.2
 numpy==1.14
 jupyter==1.0

--- a/tutorials/notebooks/FITS-cubes/requirements.txt
+++ b/tutorials/notebooks/FITS-cubes/requirements.txt
@@ -1,7 +1,7 @@
 astropy=2.0.2
 numpy=1.13.3
 matplotlib=2.1.0
-astroquery==0.3.7
+astroquery>=0.3.7
 ipython=6.2.1
 aplpy=1.1.1
 spectral-cube=0.4.1


### PR DESCRIPTION
We started to see old issues (https://travis-ci.org/astropy/astropy-tutorials/builds/390649359#L871) that has been solved for a while upstream in astroquery (https://github.com/astropy/astroquery/issues/1021).

It's not perfectly clear why the notebook started to run into it again, I suspect there may be some issues with the versions installed (#234), but as the first measure we should let the installer to pick up more recent astroqueries (given it's not like other packages, if an old version used to work, it's not guaranteed at all it still works due to its dependency on upstream services that can change beyond our control).

