### PR TITLE
Allow kernel setting from environment variable

### DIFF
--- a/tutorials/conf.py
+++ b/tutorials/conf.py
@@ -174,8 +174,12 @@ from convert import process_notebooks
 nb_tutorials_path = os.path.join(_root, 'tutorials', 'notebooks')
 template_path = os.path.join(_root, 'tutorials', 'astropy.tpl')
 rst_output_path = os.path.join(_root, 'tutorials', 'rst-tutorials')
-process_notebooks(nb_tutorials_path, output_path=rst_output_path,
-                  template_file=template_path)
+
+processkwargs = dict(output_path=rst_output_path, template_file=template_path)
+if os.environ.get('NBCONVERT_KERNEL'):  # this allows easy access from "make html"
+    processkwargs['kernel_name'] = os.environ.get('NBCONVERT_KERNEL')
+
+process_notebooks(nb_tutorials_path, **processkwargs)
 
 
 suppress_warnings = ['image.nonlocal_uri']

--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -95,6 +95,19 @@ do::
 Once this is done, you will find the index for the pages in your local
 ``build/html/index.html`` file.
 
+If you use multiple environments to manage your python installation, you
+might be surprised to find that by default this build does *not* use the
+same python environment you are running sphinx in.  This is because the
+nbconvert machinery depends on Jupyter kernels to create a separated
+environment to run each notebook.  To use a specific environment, you will
+need to use the ``jupyter kernelspec`` or ``ipykernel install`` command
+to create a named kernel for
+your favored environment. Then pass it into sphinx using the ``NBCONVERT_KERNEL``
+environment variable.  Something like::
+
+     $ python -m ipykernel install --user --name astropy-tutorials --display-name "Python (astropy-tutorials)"
+     $ NBCONVERT_KERNEL=astropy-tutorials make html
+
 Releases
 --------
 

--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -98,7 +98,7 @@ Once this is done, you will find the index for the pages in your local
 If you use multiple environments to manage your python installation, you
 might be surprised to find that by default this build does *not* use the
 same python environment you are running sphinx in.  This is because the
-nbconvert machinery depends on Jupyter kernels to create a separated
+``nbconvert`` machinery depends on Jupyter kernels to create a separate
 environment to run each notebook.  To use a specific environment, you will
 need to use the ``jupyter kernelspec`` or ``ipykernel install`` command
 to create a named kernel for


### PR DESCRIPTION
This adds a bit to the ``conf.py`` to grab an environment variable to use for determining which kernel runs the notebooks.  Also adds a bit to the dev docs to explain this.

I'm not super happy using an environment variable for this, but I couldn't come up with any other way that works with ``make html``.  Open to ideas but if no one else has something this is better than nothing.

cc @MananAgarwal @adrn