### PR TITLE
Make tutorial headers more uniform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ pip-run: &pip-install
   command: |
     python3 -m venv venv
     . venv/bin/activate
-    pip install -q -r pip-requirements.txt
+    pip install -r pip-requirements.txt
     pip install astropy_helpers sphinx pytest
     pip install git+https://github.com/jupyter/nbconvert
 

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -48,7 +48,6 @@ class NBTutorialsConverter(object):
         self._execute_kwargs = dict(timeout=900)
         if kernel_name:
             self._execute_kwargs['kernel_name'] = kernel_name
-            # self.kernel_name = ExecutePreprocessor.kernel_name.default_value
 
     def execute(self, write=True):
         """

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -13,6 +13,15 @@ import nbformat
 
 IPYTHON_VERSION = 4
 
+def clean_keyword(kw):
+    """Given a keyword parsed from the header of one of the tutorials, return
+    a 'cleaned' keyword that can be used by the filtering machinery.
+
+    - Replaces spaces with capital letters
+    - Removes . / and space
+    """
+    return kw.strip().title().replace('.', '').replace('/', '').replace(' ', '')
+
 class NBTutorialsConverter(object):
 
     def __init__(self, nb_path, output_path=None, template_file=None,
@@ -149,20 +158,20 @@ class NBTutorialsConverter(object):
 
         if match:
             keywords = match.groups()[0].split(',')
-            keywords = [k.strip() for k in keywords if k.strip()]
+            keywords = [clean_keyword(k) for k in keywords if k.strip()]
 
         # Add metatags to top of RST files to get rendered into HTML, used for
         # the search and filter functionality in Learn Astropy
-        meta_tutorials = '.. meta::\n    :keywords: filterTutorials\n'
+        meta_tutorials = '.. meta::\n    :keywords: {0}\n'
+        filters = ['filterTutorials'] + ['filter{0}'.format(k)
+                                         for k in keywords]
+        meta_tutorials = meta_tutorials.format(', '.join(filters))
         with open(output_file_path, 'r') as f:
             rst_text = f.read()
 
         with open(output_file_path, 'w') as f:
-            rst_text = '{0}\n{1}'.format(rst_text, meta_tutorials)
+            rst_text = '{0}\n{1}'.format(meta_tutorials, rst_text)
             f.write(rst_text)
-
-        # TODO: now what? need to add some sphinx stuff to the top of the RST
-        # tile to generate metadata tags in the rendered HTML
 
         if remove_executed: # optionally, clean up the executed notebook file
             remove(self._executed_nb_path)

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -159,12 +159,14 @@ class NBTutorialsConverter(object):
         if match:
             keywords = match.groups()[0].split(',')
             keywords = [clean_keyword(k) for k in keywords if k.strip()]
+            keyword_filters = ['filter{0}'.format(k) for k in keywords]
+        else:
+            keyword_filters = []
 
         # Add metatags to top of RST files to get rendered into HTML, used for
         # the search and filter functionality in Learn Astropy
         meta_tutorials = '.. meta::\n    :keywords: {0}\n'
-        filters = ['filterTutorials'] + ['filter{0}'.format(k)
-                                         for k in keywords]
+        filters = ['filterTutorials'] + keyword_filters
         meta_tutorials = meta_tutorials.format(', '.join(filters))
         with open(output_file_path, 'r') as f:
             rst_text = f.read()

--- a/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
+++ b/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
@@ -4,14 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Getting Started with astropy.coordinates"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Authors:\n",
+    "# Getting Started with astropy.coordinates\n",
+    "\n",
+    "## Authors\n",
     "Erik Tollerud, Kelle Cruz, Stephen Pardy\n",
     "\n",
     "## Learning Goals\n",
@@ -19,9 +14,11 @@
     "- Interact with a `SkyCoord` object and access its attributes\n",
     "- Use a `SkyCoord` object to query a database\n",
     "\n",
-    "## Keywords:\n",
+    "## Keywords\n",
     "astropy.coordinates, OOP\n",
     "\n",
+    "\n",
+    "## Summary\n",
     "In this tutorial, we're going to investigate the area of the sky around the picturesque group of galaxies named \"Hickson Compact Group 7\", download an image and do something with its coordinates."
    ]
   },

--- a/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
+++ b/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
@@ -15,7 +15,7 @@
     "- Use a `SkyCoord` object to query a database\n",
     "\n",
     "## Keywords\n",
-    "astropy.coordinates, OOP\n",
+    "coordinates, OOP\n",
     "\n",
     "\n",
     "## Summary\n",

--- a/tutorials/notebooks/Coordinates-Transform/Coordinates-Transform.ipynb
+++ b/tutorials/notebooks/Coordinates-Transform/Coordinates-Transform.ipynb
@@ -4,28 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Transforming between coordinate systems"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Authors:\n",
-    "Erik Tollerud, Kelle Cruz, Stephen Pardy\n",
+    "# Transforming between coordinate systems\n",
     "\n",
-    "## Prereqs\n",
-    "- Have basic knowledge of coordinate systems and the `astropy.coordinates` library\n",
-    "- How to work with python classes (note: you do not need to know how to write classes)\n",
-    "- How to work with `numpy` arrays\n",
+    "## Authors\n",
+    "Erik Tollerud, Kelle Cruz, Stephen Pardy\n",
     "\n",
     "## Learning Goals\n",
     "- Make coordinate objects\n",
     "- Transform to different coordinate systems\n",
     "- See how to track an object's altitude from certain observing locations\n",
     "\n",
-    "## Keywords:\n",
-    "units, OOP, matplotlib, numpy"
+    "## Keywords\n",
+    "matplotlib, numpy, astropy.coordinates, astropy.units\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "Demonstrates how to define astronomical coordinates using the `astropy.coordinates` \"frame\" classes. Then shows how to transform between the different built-in coordinate frames, such as from ICRS (ra, dec) to Galactic (l, b)."
    ]
   },
   {

--- a/tutorials/notebooks/Coordinates-Transform/Coordinates-Transform.ipynb
+++ b/tutorials/notebooks/Coordinates-Transform/Coordinates-Transform.ipynb
@@ -15,7 +15,7 @@
     "- See how to track an object's altitude from certain observing locations\n",
     "\n",
     "## Keywords\n",
-    "matplotlib, numpy, astropy.coordinates, astropy.units\n",
+    "coordinates, units\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/FITS-cubes/FITS-cubes.ipynb
+++ b/tutorials/notebooks/FITS-cubes/FITS-cubes.ipynb
@@ -17,7 +17,7 @@
     "* Create intensity moment maps with spectral_cube\n",
     "\n",
     "## Keywords\n",
-    "FITS-files, FITS-images, FITS-cubes, moment_maps, contours\n",
+    "FITS, radio astronomy, data cubes, contour plots\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/FITS-cubes/FITS-cubes.ipynb
+++ b/tutorials/notebooks/FITS-cubes/FITS-cubes.ipynb
@@ -4,13 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Working with FITS-cubes "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "# Working with FITS-cubes \n",
+    "\n",
     "## Authors\n",
     "[Dhanesh Krishnarao (DK)](http://www.astronomy.dk), [Shravan Shetty](http://www.astro.wisc.edu/our-people/post-doctoral-students/shetty-shravan/), [Diego Gonzalez-Casanova](http://www.astro.wisc.edu/our-people/graduate-students/gonzalez-casanova-diego/), [Audra Hernandez](http://www.astro.wisc.edu/our-people/scientists/hernandez-audra/)\n",
     "\n",
@@ -23,6 +18,8 @@
     "\n",
     "## Keywords\n",
     "FITS-files, FITS-images, FITS-cubes, moment_maps, contours\n",
+    "\n",
+    "## Summary\n",
     "\n",
     "In the tutorial we will visualize 2D and 3D data sets in different coordinates (galactic and equatorial). \n",
     "\n",

--- a/tutorials/notebooks/FITS-header/FITS-header.ipynb
+++ b/tutorials/notebooks/FITS-header/FITS-header.ipynb
@@ -4,13 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Edit a FITS header"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "# Edit a FITS header\n",
+    "\n",
+    "## Authors\n",
+    "Adrian Price-Whelan, Adam Ginsburg\n",
+    "\n",
+    "## Learning Goals\n",
+    "* Read a FITS file and retrieve the header metadata\n",
+    "* Edit the FITS header and write the modified file as a FITS file\n",
+    "\n",
+    "## Keywords\n",
+    "FITS, input/output\n",
+    "\n",
+    "## Summary\n",
     "This tutorial describes how to read in, edit a FITS header, and then write \n",
     "it back out to disk. For this example we're going to change the `OBJECT` \n",
     "keyword.\n",
@@ -250,7 +256,7 @@
    "published": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },

--- a/tutorials/notebooks/FITS-header/FITS-header.ipynb
+++ b/tutorials/notebooks/FITS-header/FITS-header.ipynb
@@ -14,7 +14,7 @@
     "* Edit the FITS header and write the modified file as a FITS file\n",
     "\n",
     "## Keywords\n",
-    "FITS, input/output\n",
+    "FITS header, file input/output\n",
     "\n",
     "## Summary\n",
     "This tutorial describes how to read in, edit a FITS header, and then write \n",

--- a/tutorials/notebooks/FITS-images/FITS-images.ipynb
+++ b/tutorials/notebooks/FITS-images/FITS-images.ipynb
@@ -13,7 +13,7 @@
     "- TODO\n",
     "\n",
     "## Keywords\n",
-    "matplotlib, FITS, images, astropy.table, astropy.io\n",
+    "matplotlib, FITS image, table\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/FITS-images/FITS-images.ipynb
+++ b/tutorials/notebooks/FITS-images/FITS-images.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Viewing and manipulating FITS images\n",
+    "\n",
+    "## Authors\n",
+    "Lia Corrales\n",
+    "\n",
+    "## Learning Goals\n",
+    "- TODO\n",
+    "\n",
+    "## Keywords\n",
+    "matplotlib, FITS, images, astropy.table, astropy.io\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "Demonstrates the use of `astropy.utils.data` to download a data file, uses `astropy.io.fits` to open the file, uses `matplotlib` to view the image with different color scales and stretches and to make histrograms. Also includes a demonstration of simple image stacking."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -10,47 +30,25 @@
     "\n",
     "# Set up matplotlib\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The following line is needed to download the example FITS files used here."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.utils.data import download_file"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Viewing and manipulating FITS images"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "%matplotlib inline\n",
+    "\n",
     "from astropy.io import fits"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cell is needed to download the example FITS files used here."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "from astropy.utils.data import download_file\n",
     "image_file = download_file('http://data.astropy.org/tutorials/FITS-images/HorseHead.fits', cache=True )"
    ]
   },
@@ -465,7 +463,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Viewing and manipulating data from FITS tables\n",
+    "\n",
+    "## Authors\n",
+    "Lia Corrales\n",
+    "\n",
+    "## Learning Goals\n",
+    "- TODO\n",
+    "\n",
+    "## Keywords\n",
+    "astropy.table, astropy.io, matplotlib, FITS, images\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "Demonstrates the use of `astropy.utils.data` to download a data file, uses `astropy.io.fits` and `astropy.table` to open the file, uses `matplotlib` to visualize the data."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -32,13 +52,6 @@
    "outputs": [],
    "source": [
     "from astropy.utils.data import download_file"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Viewing and manipulating data from FITS tables"
    ]
   },
   {
@@ -352,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
@@ -13,7 +13,7 @@
     "- TODO\n",
     "\n",
     "## Keywords\n",
-    "astropy.table, astropy.io, matplotlib, FITS, images\n",
+    "table, file input/output, matplotlib, FITS image\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/Models-Quick-Fit/Models-Quick-Fit.ipynb
+++ b/tutorials/notebooks/Models-Quick-Fit/Models-Quick-Fit.ipynb
@@ -16,7 +16,7 @@
     "* Visualize the fit\n",
     "\n",
     "## Keywords\n",
-    "astropy.modeling, model fitting, astroquery, matplotlib\n",
+    "modeling, model fitting, astroquery, matplotlib, astrostatistics\n",
     "\n",
     "## Summary\n",
     "In this tutorial, we will become familiar with the models available in `astropy.modeling` and learn how to make a quick fit to our data."

--- a/tutorials/notebooks/Models-Quick-Fit/Models-Quick-Fit.ipynb
+++ b/tutorials/notebooks/Models-Quick-Fit/Models-Quick-Fit.ipynb
@@ -7,7 +7,7 @@
     "# Make a quick fit using astropy.modeling\n",
     "\n",
     "## Authors\n",
-    "Rocio Kiman, Lia Corrales and Zé Vinícius.\n",
+    "Rocio Kiman, Lia Corrales, and Zé Vinícius.\n",
     "\n",
     "## Learning Goals\n",
     "* Know basic models in Astropy Modeling\n",
@@ -16,7 +16,7 @@
     "* Visualize the fit\n",
     "\n",
     "## Keywords\n",
-    "Modeling, Fit \n",
+    "astropy.modeling, model fitting, astroquery, matplotlib\n",
     "\n",
     "## Summary\n",
     "In this tutorial, we will become familiar with the models available in `astropy.modeling` and learn how to make a quick fit to our data."

--- a/tutorials/notebooks/UVES/UVES.ipynb
+++ b/tutorials/notebooks/UVES/UVES.ipynb
@@ -4,35 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Analyzing UVES Spectroscopy with Astropy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Acknowledgments"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "License: This tutorial is made available under the terms of the\n",
-    "[Creative Commons Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/)\n",
+    "# Analyzing UVES Spectroscopy with Astropy\n",
     "\n",
-    "Authors: Moritz Guenther, Miguel de Val-Borro\n",
+    "## Authors\n",
+    "Moritz Guenther, Miguel de Val-Borro\n",
     "\n",
-    "Copyright: 2013 - 2015 Moritz Guenther, Miguel de Val-Borro\n",
+    "## Learning Goals\n",
+    "* TODO\n",
     "\n",
-    "Based on observations made with ESO Telescopes at the La Silla Paranal Observatory\n",
-    "under program ID 087.V0991(A)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "## Keywords\n",
+    "matplotlib, astropy.io, astropy.wcs, astropy.units, astropy.constants, FITS\n",
+    "\n",
+    "## Summary\n",
     "This tutorial follows my real live data analysis of MN Lup and the code developed\n",
     "below is taken (with only minor modifications) from the code that I used to\n",
     "actually prepare the publication. The plots that will be developed below\n",
@@ -46,7 +29,16 @@
     "\n",
     "Also, this tutorial works best if you follow along and execute the code shown\n",
     "on your own computer. The page is already quite long and I do not include the\n",
-    "output you would see on your screen in this document."
+    "output you would see on your screen in this document.\n",
+    "\n",
+    "## Acknowledgments\n",
+    "License: This tutorial is made available under the terms of the\n",
+    "[Creative Commons Attribution 3.0 License](http://creativecommons.org/licenses/by/3.0/)\n",
+    "\n",
+    "Copyright: 2013 - 2015 Moritz Guenther, Miguel de Val-Borro\n",
+    "\n",
+    "Based on observations made with ESO Telescopes at the La Silla Paranal Observatory\n",
+    "under program ID 087.V0991(A)."
    ]
   },
   {
@@ -1416,7 +1408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/UVES/UVES.ipynb
+++ b/tutorials/notebooks/UVES/UVES.ipynb
@@ -13,7 +13,7 @@
     "* TODO\n",
     "\n",
     "## Keywords\n",
-    "matplotlib, astropy.io, astropy.wcs, astropy.units, astropy.constants, FITS\n",
+    "matplotlib, file input/output, wcs, units, FITS image\n",
     "\n",
     "## Summary\n",
     "This tutorial follows my real live data analysis of MN Lup and the code developed\n",

--- a/tutorials/notebooks/plot-catalog/plot-catalog.ipynb
+++ b/tutorials/notebooks/plot-catalog/plot-catalog.ipynb
@@ -10,14 +10,16 @@
     "Adrian Price-Whelan, Kelle Cruz\n",
     "\n",
     "## Learning Goals\n",
-    "* TODO\n",
+    "* Read an ASCII file using `astropy.io`\n",
+    "* Convert between representations of coordinate components using `astropy.coordinates` (hours to degrees)\n",
+    "* Make a spherical projection sky plot using `matplotlib`\n",
     "\n",
     "## Keywords\n",
     "astropy.io.ascii, astropy.coordinates, units, matplotlib\n",
     "\n",
     "## Summary\n",
     "\n",
-    "Demonstrates the use of `astropy.io.ascii` for reading and writing ASCII data, `astropy.coordinates` and `astropy.units` for converting RA (as a sexagesimal angle) to decimal degrees, and `matplotlib` for making a color-magnitude diagram and on-sky locations in a mollweide projection."
+    "Demonstrates the use of `astropy.io.ascii` for reading ASCII data, `astropy.coordinates` and `astropy.units` for converting RA (as a sexagesimal angle) to decimal degrees, and `matplotlib` for making a color-magnitude diagram and on-sky locations in a mollweide projection."
    ]
   },
   {

--- a/tutorials/notebooks/plot-catalog/plot-catalog.ipynb
+++ b/tutorials/notebooks/plot-catalog/plot-catalog.ipynb
@@ -15,7 +15,7 @@
     "* Make a spherical projection sky plot using `matplotlib`\n",
     "\n",
     "## Keywords\n",
-    "astropy.io.ascii, astropy.coordinates, units, matplotlib\n",
+    "file input/output, coordinates, units, matplotlib\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/plot-catalog/plot-catalog.ipynb
+++ b/tutorials/notebooks/plot-catalog/plot-catalog.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Read in catalog information from a text file and plot some parameters\n",
+    "\n",
+    "## Authors\n",
+    "Adrian Price-Whelan, Kelle Cruz\n",
+    "\n",
+    "## Learning Goals\n",
+    "* TODO\n",
+    "\n",
+    "## Keywords\n",
+    "astropy.io.ascii, astropy.coordinates, units, matplotlib\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "Demonstrates the use of `astropy.io.ascii` for reading and writing ASCII data, `astropy.coordinates` and `astropy.units` for converting RA (as a sexagesimal angle) to decimal degrees, and `matplotlib` for making a color-magnitude diagram and on-sky locations in a mollweide projection."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -11,13 +31,6 @@
     "# Set up matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Read in catalog information from a text file and plot some parameters"
    ]
   },
   {
@@ -447,7 +460,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/quantities/quantities.ipynb
+++ b/tutorials/notebooks/quantities/quantities.ipynb
@@ -13,7 +13,7 @@
     "* TODO\n",
     "\n",
     "## Keywords\n",
-    "astropy.units, astropy.constants, quantity, matplotlib\n",
+    "units, matplotlib, radio astronomy\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/quantities/quantities.ipynb
+++ b/tutorials/notebooks/quantities/quantities.ipynb
@@ -4,13 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using Astropy Quantities for astrophysical calculations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "# Using Astropy Quantities for astrophysical calculations\n",
+    "\n",
+    "## Authors\n",
+    "Ana Bonaca, Erik Tollerud, Jonathan Foster\n",
+    "\n",
+    "## Learning Goals\n",
+    "* TODO\n",
+    "\n",
+    "## Keywords\n",
+    "astropy.units, astropy.constants, quantity, matplotlib\n",
+    "\n",
+    "## Summary\n",
+    "\n",
     "In this tutorial we present some examples showing how astropy's `Quantity` object can make astrophysics calculations easier. The examples include calculating the mass of a galaxy from its velocity dispersion and determining masses of molecular clouds from CO intensity maps. We end with an example of good practices for using quantities in functions you might distribute to other people.\n",
     "\n",
     "For an in-depth discussion of `Quantity` objects, see the [astropy documentation section](http://docs.astropy.org/en/stable/units/quantity.html)."
@@ -1090,7 +1096,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/redshift-plot/redshift-plot.ipynb
+++ b/tutorials/notebooks/redshift-plot/redshift-plot.ipynb
@@ -13,7 +13,7 @@
     "* TODO\n",
     "\n",
     "## Keywords\n",
-    "astropy.units, astropy.cosmology, matplotlib\n",
+    "units, cosmology, matplotlib\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/redshift-plot/redshift-plot.ipynb
+++ b/tutorials/notebooks/redshift-plot/redshift-plot.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Make a plot with both redshift and universe age axes using astropy.cosmology\n",
+    "\n",
+    "## Authors\n",
+    "Neil Crighton\n",
+    "\n",
+    "## Learning Goals\n",
+    "* TODO\n",
+    "\n",
+    "## Keywords\n",
+    "astropy.units, astropy.cosmology, matplotlib\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "Each redshift corresponds to an age of the universe, so if you're plotting some quantity against redshift, it's often useful show the universe age too.  The relationship between the two changes depending the type of cosmology you assume, which is where `astropy.cosmology` comes in. In this tutorial we'll show how to use the tools in `astropy.cosmology` to make a plot like this:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -11,15 +31,6 @@
     "# Set up matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Make a plot with both redshift and universe age axes using astropy.cosmology\n",
-    "\n",
-    "Each redshift corresponds to an age of the universe, so if you're plotting some quantity against redshift, it's often useful show the universe age too.  The relationship between the two changes depending the type of cosmology you assume, which is where `astropy.cosmology` comes in. In this tutorial we'll show how to use the tools in `astropy.cosmology` to make a plot like this:"
    ]
   },
   {
@@ -340,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/synthetic-images/synthetic-images.ipynb
+++ b/tutorials/notebooks/synthetic-images/synthetic-images.ipynb
@@ -4,13 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Synthetic Images from simulated data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "# Synthetic Images from simulated data\n",
+    "\n",
     "## Authors\n",
     "Yi-Hao Chen & Sebastian Heinz\n",
     "\n",
@@ -23,9 +18,9 @@
     "- Overplot quivers on the image\n",
     "\n",
     "## Keywords\n",
-    "astrometry, WCS, fits image, fits Header, polarization, radio, stokes parameters, PSF, convolution, quiver plot, visualization\n",
+    "astrometry, WCS, FITS, polarization, radio, stokes parameters, PSF, astropy.convolution, quiver plot, astropy.visualization, matplotlib, astropy.wcs\n",
     "\n",
-    "\n",
+    "## Summary\n",
     "In this tutorial, we will:\n",
     "\n",
     "[1. Load and examine the FITS file](#1.-Load-and-examine-the-FITS-file)\n",

--- a/tutorials/notebooks/synthetic-images/synthetic-images.ipynb
+++ b/tutorials/notebooks/synthetic-images/synthetic-images.ipynb
@@ -18,7 +18,7 @@
     "- Overplot quivers on the image\n",
     "\n",
     "## Keywords\n",
-    "astrometry, WCS, FITS, polarization, radio, stokes parameters, PSF, astropy.convolution, quiver plot, astropy.visualization, matplotlib, astropy.wcs\n",
+    "astrometry, WCS, FITS image, radio astronomy, visualization, matplotlib\n",
     "\n",
     "## Summary\n",
     "In this tutorial, we will:\n",

--- a/tutorials/notebooks/units-and-integration/units-and-integration.ipynb
+++ b/tutorials/notebooks/units-and-integration/units-and-integration.ipynb
@@ -20,7 +20,7 @@
     "* add $\\LaTeX$ labels to `matplotlib` figures using the `latex_inline` formatter\n",
     "\n",
     "## Keywords\n",
-    "integration, OOP, LaTeX, Planck function, probability, matplotlib, astropy.modeling, astropy.units, astropy.constants\n",
+    "OOP, LaTeX, astrostatistics, matplotlib, modeling, units\n",
     "\n",
     "## Companion Content\n",
     "* http://synphot.readthedocs.io/en/latest/\n",

--- a/tutorials/notebooks/units-and-integration/units-and-integration.ipynb
+++ b/tutorials/notebooks/units-and-integration/units-and-integration.ipynb
@@ -4,15 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using `scipy.integrate`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "# Using `scipy.integrate`\n",
+    "\n",
     "## Authors\n",
-    "Zach Pace (September 2017), Lia Corrales (February 2018)\n",
+    "Zach Pace, Lia Corrales\n",
     "\n",
     "## Learning Goals\n",
     "* perform numerical integration in the `astropy` and scientific python context\n",
@@ -25,14 +20,13 @@
     "* add $\\LaTeX$ labels to `matplotlib` figures using the `latex_inline` formatter\n",
     "\n",
     "## Keywords\n",
-    "integration, python classes, LaTeX, Planck function, probability\n",
+    "integration, OOP, LaTeX, Planck function, probability, matplotlib, astropy.modeling, astropy.units, astropy.constants\n",
     "\n",
     "## Companion Content\n",
-    "\n",
     "* http://synphot.readthedocs.io/en/latest/\n",
     "* [Using Astropy Quantities for astrophysical calculations](http://astropy-tutorials.readthedocs.io/en/latest/rst-tutorials/quantities.html)\n",
     "\n",
-    "\n",
+    "## Summary\n",
     "In this tutorial, we will use the examples of the Planck function and the stellar initial mass function (IMF) to illustrate how to integrate numerically, using the trapezoidal approximation and Gaussian quadrature. We will also explore making a custom class, an instance of which is callable in the same way as a function. In addition, we will encounter `astropy`'s built-in units, and get a first taste of how to convert between them. Finally, we will use $\\LaTeX$ to make our figure axis labels easy to read."
    ]
   },
@@ -357,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/tutorials/notebooks/vo/conesearch.ipynb
+++ b/tutorials/notebooks/vo/conesearch.ipynb
@@ -6,14 +6,21 @@
     "description": "VO Simple Cone Search basic tutorial."
    },
    "source": [
-    "# VO Simple Cone Search Tutorial"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This tutorial requires `astroquery` 0.3.5 or greater. Cone Search allows you to query a catalog of astronomical sources and obtain those that lie within a cone of a given radius around the given position. For more information on Cone Search, see http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html."
+    "# VO Simple Cone Search Tutorial\n",
+    "\n",
+    "## Authors\n",
+    "P. L. Lim\n",
+    "\n",
+    "## Learning Goals\n",
+    "* TODO\n",
+    "\n",
+    "## Keywords\n",
+    "matplotlib, astropy.table, astropy.coordinates, astropy.units, conesearch\n",
+    "\n",
+    "## Summary\n",
+    "Cone Search allows you to query a catalog of astronomical sources and obtain those that lie within a cone of a given radius around the given position. For more information on Cone Search, see http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html.\n",
+    "\n",
+    "This tutorial requires `astroquery` 0.3.5 or greater. "
    ]
   },
   {

--- a/tutorials/notebooks/vo/conesearch.ipynb
+++ b/tutorials/notebooks/vo/conesearch.ipynb
@@ -15,7 +15,7 @@
     "* TODO\n",
     "\n",
     "## Keywords\n",
-    "matplotlib, astropy.table, astropy.coordinates, astropy.units, conesearch\n",
+    "matplotlib, table, coordinates, units, conesearch\n",
     "\n",
     "## Summary\n",
     "Cone Search allows you to query a catalog of astronomical sources and obtain those that lie within a cone of a given radius around the given position. For more information on Cone Search, see http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html.\n",


### PR DESCRIPTION
This is a first stab at making the tutorial headers (i.e. the first markdown cell in each notebook) more uniform across the tutorials. We need this for #247 so that each notebook specifies a set of keywords. I tried to add summaries where notebooks didn't have them, but many are missing learning goals. 

Could the authors please provide a set of learning goals (bulleted list of a few key takeaways) for:
* Viewing and manipulating FITS images (author @eblur)
* Viewing and manipulating FITS tables (author @eblur)
* Using Astropy Quantities for astrophysical calculations (authors Ana Bonaca, @eteq)
* Make a plot with both redshift and universe age axes using astropy.cosmology (author Neil Crighton)
* Analyzing UVES Spectroscopy with Astropy (@hamogu @migueldvb)
* VO Simple Cone Search Tutorial (@pllim)

This also then adds functionality for parsing out keywords from the newly uniform headers, and generates HTML meta tags from the keywords to be used in the javascript filtering functionality added in #247

This fixes #239 