### PR TITLE
Add option to run one notebook file

### DIFF
--- a/tutorials/conf.py
+++ b/tutorials/conf.py
@@ -179,8 +179,8 @@ processkwargs = dict(output_path=rst_output_path, template_file=template_path)
 if os.environ.get('NBCONVERT_KERNEL'):  # this allows access from "make html"
     processkwargs['kernel_name'] = os.environ.get('NBCONVERT_KERNEL')
 
-if os.environ.get('NB'):  # this allows only building a single tutorial file
-    nb_tutorials_path = os.path.abspath(os.environ.get('NB'))
+if os.environ.get('NBFILE'):  # this allows only building a single tutorial file
+    nb_tutorials_path = os.path.abspath(os.environ.get('NBFILE'))
 
 process_notebooks(nb_tutorials_path, **processkwargs)
 

--- a/tutorials/conf.py
+++ b/tutorials/conf.py
@@ -176,8 +176,11 @@ template_path = os.path.join(_root, 'tutorials', 'astropy.tpl')
 rst_output_path = os.path.join(_root, 'tutorials', 'rst-tutorials')
 
 processkwargs = dict(output_path=rst_output_path, template_file=template_path)
-if os.environ.get('NBCONVERT_KERNEL'):  # this allows easy access from "make html"
+if os.environ.get('NBCONVERT_KERNEL'):  # this allows access from "make html"
     processkwargs['kernel_name'] = os.environ.get('NBCONVERT_KERNEL')
+
+if os.environ.get('NB'):  # this allows only building a single tutorial file
+    nb_tutorials_path = os.path.abspath(os.environ.get('NB'))
 
 process_notebooks(nb_tutorials_path, **processkwargs)
 

--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -95,6 +95,10 @@ do::
 Once this is done, you will find the index for the pages in your local
 ``build/html/index.html`` file.
 
+For testing, you may want to run the build process on just one notebook file, as the full build takes some time to execute and convert all of the tutorial notebooks. To do this, you can set the ``NB`` environment variable to specify the path to a notebook file relative to the ``tutorials`` path. For example, to run the build process on just the FITS-header tutorial::
+
+    $ NB=notebooks/FITS-header/FITS-header.ipynb make html
+
 If you use multiple environments to manage your python installation, you
 might be surprised to find that by default this build does *not* use the
 same python environment you are running sphinx in.  This is because the

--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -97,11 +97,11 @@ Once this is done, you will find the index for the pages in your local
 
 For testing, you may want to run the build process on just one notebook file, as
 the full build takes some time to execute and convert all of the tutorial
-notebooks. To do this, you can set the ``NB`` environment variable to specify
-the path to a notebook file relative to the ``tutorials`` path. For example, to
-run the build process on just the FITS-header tutorial::
+notebooks. To do this, you can set the ``NBFILE`` environment variable to
+specify the path to a notebook file relative to the ``tutorials`` path. For
+example, to run the build process on just the FITS-header tutorial::
 
-    $ NB=notebooks/FITS-header/FITS-header.ipynb make html
+    $ NBFILE=notebooks/FITS-header/FITS-header.ipynb make html
 
 If you use multiple environments to manage your python installation, you
 might be surprised to find that by default this build does *not* use the

--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -95,7 +95,11 @@ do::
 Once this is done, you will find the index for the pages in your local
 ``build/html/index.html`` file.
 
-For testing, you may want to run the build process on just one notebook file, as the full build takes some time to execute and convert all of the tutorial notebooks. To do this, you can set the ``NB`` environment variable to specify the path to a notebook file relative to the ``tutorials`` path. For example, to run the build process on just the FITS-header tutorial::
+For testing, you may want to run the build process on just one notebook file, as
+the full build takes some time to execute and convert all of the tutorial
+notebooks. To do this, you can set the ``NB`` environment variable to specify
+the path to a notebook file relative to the ``tutorials`` path. For example, to
+run the build process on just the FITS-header tutorial::
 
     $ NB=notebooks/FITS-header/FITS-header.ipynb make html
 


### PR DESCRIPTION
In the spirit of the new `NBCONVERT_KERNEL` environment variable, this PR adds a check for the `NBFILE` environment variable, which allows specifying the path to a single notebook file to execute and build. This is very useful for testing the end-to-end build process on a single tutorial first, before running on all tutorials (which takes quite a bit of time!).

(Also, to work with a newer version of `jupyter_client` released within the last week or so, I had to remove the default kernel name `ExecutePreprocessor.kernel_name.default_value` added by @eteq)