### PR TITLE
Remove backticks from links in UVES tutorial

### DIFF
--- a/tutorials/notebooks/UVES/UVES.ipynb
+++ b/tutorials/notebooks/UVES/UVES.ipynb
@@ -15,11 +15,11 @@
     "Moritz Guenther, Miguel de Val-Borro, Emily Rice (Learning Goals & formatting)\n",
     "\n",
     "## Learning Goals\n",
-    "* *Input/Output*: Read in spectral data from a list of FITS files using [`astropy.io`](http://docs.astropy.org/en/stable/io/fits/index.html) and [`astropy.wcs`](http://docs.astropy.org/en/stable/wcs/index.html)\n",
+    "* *Input/Output*: Read in spectral data from a list of FITS files using [astropy.io](http://docs.astropy.org/en/stable/io/fits/index.html) and [astropy.wcs](http://docs.astropy.org/en/stable/wcs/index.html)\n",
     "* *Coding*: Make code reusable as a function\n",
-    "* *Analysis*: Analyze spectral data using [`astropy.units`](http://docs.astropy.org/en/stable/units/index.html),  [`astropy.constants`](http://docs.astropy.org/en/stable/constants/index.html), and [`astropy.time`](http://docs.astropy.org/en/stable/time/index.html)\n",
-    "* *Input/Output*: Generate a LaTeX table using [`astropy.table`](http://docs.astropy.org/en/stable/table/index.html)\n",
-    "* *Visualization*: Plot spectral data using [`matplotlib`](https://matplotlib.org/) \n",
+    "* *Analysis*: Analyze spectral data using [astropy.units](http://docs.astropy.org/en/stable/units/index.html),  [astropy.constants](http://docs.astropy.org/en/stable/constants/index.html), and [astropy.time](http://docs.astropy.org/en/stable/time/index.html)\n",
+    "* *Input/Output*: Generate a LaTeX table using [astropy.table](http://docs.astropy.org/en/stable/table/index.html)\n",
+    "* *Visualization*: Plot spectral data using [matplotlib](https://matplotlib.org/)\n",
     "\n",
     "## Keywords:\n",
     "astropy.io, astropy.wcs, astropy.units, astropy.constants, astropy.time, astropy.table, matplotlib, spectra, UVES\n",
@@ -1320,7 +1320,7 @@
    "published": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -1334,7 +1334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Backticks in markdown links cause issues when converted to RST.