### PR TITLE
Fixed the scrolling issue on tutorials home page

### DIFF
--- a/tutorials/themes/tutorials-theme/layout.html
+++ b/tutorials/themes/tutorials-theme/layout.html
@@ -33,8 +33,8 @@
 
 {%- macro bsidebar() %}
     {%- if render_sidebar %}
-    <div class="{{ bs_span_prefix }}3" style="padding-left: 0px;">
-      <div id="sidebar" class="bs-sidenav card" role="complementary">
+    <div class="{{ bs_span_prefix }}3">
+      <div id="sidebar" class="bs-sidenav card" role="complementary" style="position: static !important;" >
         {%- for sidebartemplate in sidebars %}
           {%- include sidebartemplate %}
         {%- endfor %}
@@ -84,7 +84,7 @@
     {% endif %}
     
     {% if pagename != "search" and pagename != "index" and pagename != "tutorials" and pagename != "documentation" and pagename != "examples" and pagename != "guides" %}
-    <div class="{{ bs_span_prefix }}3" style="padding-left: 0px;">
+    <div class="{{ bs_span_prefix }}3">
       <div id="sidebar" class="bs-sidenav card" role="complementary">
         <h3>Table of contents</h3>
         {{toc}}


### PR DESCRIPTION
I have fixed the sidebar on the tutorials home page to the top, but I have allowed the sidebar (containing the table of contents) on individual tutorial pages to stick on the screen on scrolling. This will allow the viewer to easily navigate across the tutorial. To avoid the scrolling issue in these pages, I fix the sidebar whenever the size of the browser window is reduced beyond a limit.