### PR TITLE
Link jupyter notebook style guides to Contributing.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,6 +76,7 @@ Code
     * Variable names should be descriptive, e.g., ``galaxy_mass``, ``u_mag``
 * Use the print function explicitly to display information about variables
 * As much as possible, comply with `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_.
+* As much as possible, comply with Jupyter notebook style guides - `STScI style guide <https://github.com/spacetelescope/style-guides/blob/master/guides/jupyter-notebooks.md>`_ and `Official Coding Style <https://jupyter.readthedocs.io/en/latest/development_guide/coding_style.html>`_.
 * Imports
     * Do not use ``from package import *``; import packages, classes, and
       functions explicitly


### PR DESCRIPTION
Fixes #284 

Links jupyter notebook style guides([STScI style guide](https://github.com/spacetelescope/style-guides/blob/master/guides/jupyter-notebooks.md) and [Official coding style](https://jupyter.readthedocs.io/en/latest/development_guide/coding_style.html)) to Contributing.rst