### PR TITLE
To add "data cubes" keyword to Quantities tutorial 

### DIFF
--- a/tutorials/notebooks/quantities/quantities.ipynb
+++ b/tutorials/notebooks/quantities/quantities.ipynb
@@ -13,7 +13,7 @@
     "* TODO\n",
     "\n",
     "## Keywords\n",
-    "units, matplotlib, radio astronomy\n",
+    "units, matplotlib, radio astronomy, data cubes\n",
     "\n",
     "## Summary\n",
     "\n",


### PR DESCRIPTION
To follow up on Issue #322. Adding the keyword "data cubes" to the Quantities tutorial as some part of the tutorial clearly deals with some data cube setup procedure with NumPy (as in "2. Molecular cloud mass").  

Noticed also that the "Learning Goals" have been listed as "TODO", will follow this up with another PR to add the relevant learning goals. 