### PR TITLE
Debug navbar code to fix logo broken link

### DIFF
--- a/tutorials/conf.py
+++ b/tutorials/conf.py
@@ -96,7 +96,7 @@ html_theme_options = {
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = 'astropy_favicon.ico'
+html_favicon = "_static/astropy_favicon.ico"
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/tutorials/themes/tutorials-theme/layout.html
+++ b/tutorials/themes/tutorials-theme/layout.html
@@ -27,7 +27,7 @@
 <!DOCTYPE html>
 {%- endblock %}
 
-{% macro navBar() %}
+{% macro nav_bar() %}
 {% include "navbar" + navbar_version + ".html" %}
 {% endmacro %}
 
@@ -71,7 +71,7 @@
 {% block sidebarsourcelink %}{% endblock %}
 
 {%- block content %}
-{{ navBar() }}
+{{ nav_bar() }}
 <div class="container">
   <div class="row">
     {%- block sidebar1 %}{{ bsidebar() }}{% endblock %}

--- a/tutorials/themes/tutorials-theme/navbar.html
+++ b/tutorials/themes/tutorials-theme/navbar.html
@@ -39,9 +39,10 @@
 </div>
 
 {% else %}
-
 <nav class="navbar navbar-expand-lg bg-navbar">
-  <a class="navbar-brand" href="/astropy-tutorials"style="padding: 0px 5px;"><img src="{{ pathto('_static/' + 'astropy_logo.png') }}" style="height:38px;"></a>
+  <a class="navbar-brand" href="/astropy-tutorials" style="padding: 0px 5px;">
+    <img src="{{ pathto('../_static/' + 'astropy_logo.png', 1) }}" onerror="this.onerror=null;this.src='{{ pathto("_static/" + "astropy_logo.png", 1) }}';" style="height: 38px;">
+  </a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/tutorials/themes/tutorials-theme/theme.conf
+++ b/tutorials/themes/tutorials-theme/theme.conf
@@ -14,7 +14,7 @@ sidebars =
 navbar_title =
 
 # Tab name for entire site. (Default: "Site")
-navbar_site_name = Site
+navbar_site_name = "Site"
 
 # A list of tuples containting pages to link to.  The value should be
 # in the form [(name, page), ..]
@@ -27,7 +27,7 @@ navbar_sidebarrel = true
 navbar_pagenav = true
 
 # Tab name for the current pages TOC. (Default: "Page")
-navbar_pagenav_name = Page
+navbar_pagenav_name = "Page"
 
 # Global TOC depth for "site" navbar tab. (Default: 1)
 # Switching to -1 shows all levels.
@@ -44,7 +44,7 @@ globaltoc_includehidden = true
 
 # HTML navbar class (Default: "navbar") to attach to <div> element.
 # For black navbar, do "navbar navbar-inverse"
-navbar_class = navbar
+navbar_class = navbar navbar-inverse
 
 # Fix navigation bar to top of page?
 # Values: "true" (default) or "false"


### PR DESCRIPTION
Fixes #323. 

Attempts to mend broken Astropy logo banner link on the tutorial pages, in order for the image on the left hand side of the Learn Astropy navbar to show properly. 