### PR TITLE
Add matplotlib version requirement to Quantities

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - IPython=6.1.0
   - astropy=3
   - astroquery>=0.3.7
-  - matplotlib=2.0.2
+  - matplotlib==3.0.2
   - numpy=1.14
   - scipy=1.0 # needed for coordinates cross-matching
   - jupyter=1.0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,7 +1,7 @@
 IPython>=6.1
 astropy>=3
 astroquery>=0.3.7
-matplotlib>=2.0
+matplotlib==3.0.2
 numpy>=1.15
 jupyter>=1.0
 scipy>=1.0

--- a/tutorials/notebooks/quantities/requirements.txt
+++ b/tutorials/notebooks/quantities/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-matplotlib
+matplotlib==3.0.2
 astropy


### PR DESCRIPTION
I verified that Quantities notebook `plt.hist(v)` command worked in matplotlib version 3.0.2 and forced that to be the requirement for now.

Will open an Issue with astropy quantities people so that it works in matplotlib version 3.1 (the latest).