### PR TITLE
Ignore fits and gz files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ build/
 tutorials/rst-tutorials/
 tutorials/notebooks/FITS-cubes/Maps/
 IPython-*
-*.fits
+*.fits*
+*.gz
 *.pdf
 *.jpg
 *.pyc


### PR DESCRIPTION
The gitignore file was ignoring *.fits but not *.fits.gz, so the files were getting `git add`'ed into the push. This should fix it!

This fixes #361 