### PR TITLE
Hide filterTutorials from URL

### DIFF
--- a/tutorials/themes/tutorials-theme/layout.html
+++ b/tutorials/themes/tutorials-theme/layout.html
@@ -48,13 +48,6 @@
   <meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
   <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
   <meta name="apple-mobile-web-app-capable" content="yes">
-  {# this script is to redirect /tutorials.html to /tutorials.html?q=filterTutorials #}
-  <script type="text/javascript">  
-    if( (window.location.href.search("tutorials.html") != -1) && (window.location.href.search("q=filterTutorials") == -1) ){
-      var url = window.location.href.split("tutorials.html")[0] + "tutorials.html?q=filterTutorials";
-      window.location.href = url;
-    }
-  </script>
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
   </script>
@@ -82,13 +75,13 @@
     {% else %}
       {%- set content_card = "content-padding card" %}
     {% endif %}
-    
+
     {% if pagename != "search" and pagename != "index" and pagename != "tutorials" and pagename != "documentation" and pagename != "examples" and pagename != "guides" %}
     <div class="{{ bs_span_prefix }}3">
       <div id="sidebar" class="bs-sidenav card" role="complementary">
         <h3>Table of contents</h3>
         {{toc}}
-      </div>    
+      </div>
     </div>
     {%- set bs_content_width = "9" %}
     {% endif %}
@@ -96,10 +89,10 @@
     <div class="{{ bs_span_prefix }}{{ bs_content_width }}">
       <div class="{{content_card}}">
         <div>{% block body %}{% endblock %}</div>
-      </div>  
+      </div>
       {% if pagename == "tutorials" %}
         {# This is where the tutorials will be injected based on the filters #}
-        <div id="search-results" class="tut-results"></div>  
+        <div id="search-results" class="tut-results"></div>
       {% endif %}
     </div>
   </div>
@@ -118,7 +111,7 @@
     </p>
     <p>
     {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
-    {% trans copyright=copyright|e %}&copy; Copyright Astropy.{% endtrans %}   
+    {% trans copyright=copyright|e %}&copy; Copyright Astropy.{% endtrans %}
     </p>
   </div>
 </footer>

--- a/tutorials/themes/tutorials-theme/navbar.html
+++ b/tutorials/themes/tutorials-theme/navbar.html
@@ -20,7 +20,7 @@
   </div>
   <div class="card bg-tutorial col-md-3 col-lg-2 p-0 m-2 ml-auto">
     <div class="card-body">
-        <h2 class="card-title text-center"><a href="tutorials.html?q=filterTutorials" class="text-white">Tutorials</a></h2>
+        <h2 class="card-title text-center"><a href="tutorials.html" class="text-white">Tutorials</a></h2>
       <p class="card-text text-center">Tutorials are step-by-step cookbooks for common activities that incorporate several packages. They are more specific and less conceptual than Guides but more extended than Examples.</p>
     </div>
   </div>

--- a/tutorials/themes/tutorials-theme/static/searchtools.js
+++ b/tutorials/themes/tutorials-theme/static/searchtools.js
@@ -337,9 +337,12 @@ var Search = {
       var params = $.getQueryParameters();
       if (params.q) {
           var query = params.q[0];
-          $('input[name="q"]')[0].value = query;
-          this.performSearch(query);
+      } else {
+          // If no query string is passed, assume we want to filterTutorials
+          var query = "filterTutorials";
       }
+      $('input[name="q"]')[0].value = query;
+      this.performSearch(query);
   },
 
   loadIndex : function(url) {
@@ -410,7 +413,7 @@ var Search = {
       this.deferQuery(query);
 
     //Perform search in Astropy Documentation
-      if(window.location.search.search("filterTutorials")==-1){    //if filtered by tutorials, then no need to search in Astropy Documentation
+      if (query.includes("filterTutorials")) { // don't search docs if we are just looking for tutorials
         var docResponse = null;
         var docResult = '';
         $.get('https://readthedocs.org/api/v2/docsearch/?q=' + window.location.search.split('=')[1] + '&project=astropy&version=stable&language=en', function(response){


### PR DESCRIPTION
This PR is my attempt to fix #304.

This adjusts the way the search query is handled in javascript and assumes that no query string means filterTutorials.