### PR TITLE
Add learning goals to FITS-tables tutorial

### DIFF
--- a/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
@@ -7,10 +7,12 @@
     "# Viewing and manipulating data from FITS tables\n",
     "\n",
     "## Authors\n",
-    "Lia Corrales\n",
+    "Lia Corrales, Kris Stern\n",
     "\n",
     "## Learning Goals\n",
-    "- TODO\n",
+    "1. Learn how to open the FITS file and view table contents\n",
+    "2. Learn how to make a 2-D histogram with some table data\n",
+    "3. Learn how to close the FITS file after use\n",
     "\n",
     "## Keywords\n",
     "table, file input/output, matplotlib, FITS table\n",
@@ -351,7 +353,7 @@
    "published": true
   },
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -365,9 +367,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
@@ -15,7 +15,7 @@
     "3. Learn how to close the FITS file after use\n",
     "\n",
     "## Keywords\n",
-    "table, file input/output, matplotlib, FITS table\n",
+    "table, file input/output (i/o), matplotlib, FITS table\n",
     "\n",
     "## Summary\n",
     "\n",

--- a/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/notebooks/FITS-tables/FITS-tables.ipynb
@@ -10,7 +10,7 @@
     "Lia Corrales, Kris Stern\n",
     "\n",
     "## Learning Goals\n",
-    "1. Learn how to open the FITS file and view table contents\n",
+    "1. Learn how to open a FITS file and view table contents\n",
     "2. Learn how to make a 2-D histogram with some table data\n",
     "3. Learn how to close the FITS file after use\n",
     "\n",


### PR DESCRIPTION
Fixes #368.

To add learning goals to the FITS-tables tutorial currently filled by a "TODO" placeholder. 