### PR TITLE
Change Quantities tutorial title to incorporate the term "Units"

### DIFF
--- a/tutorials/notebooks/quantities/quantities.ipynb
+++ b/tutorials/notebooks/quantities/quantities.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using Astropy Quantities for astrophysical calculations\n",
+    "# Using Astropy Quantities and Units for astrophysical calculations\n",
     "\n",
     "## Authors\n",
     "Ana Bonaca, Erik Tollerud, Jonathan Foster\n",
@@ -1512,9 +1512,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Fixes #375. 

To change the title of the Quantities to include the term "Units" to better adhere to convention used in Astropy, as at [https://docs.astropy.org/en/stable/units/](https://docs.astropy.org/en/stable/units/). 