### PR TITLE
Fix spelling of Exercise

### DIFF
--- a/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
+++ b/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
@@ -287,7 +287,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Excercise 1"
+    "### Exercise 1"
    ]
   },
   {
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Excercise 2"
+    "### Exercise 2"
    ]
   },
   {

--- a/tutorials/notebooks/Coordinates-Transform/Coordinates-Transform.ipynb
+++ b/tutorials/notebooks/Coordinates-Transform/Coordinates-Transform.ipynb
@@ -621,7 +621,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Excercise 1"
+    "### Exercise 1"
    ]
   },
   {
@@ -644,7 +644,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Excercise 2"
+    "### Exercise 2"
    ]
   },
   {
@@ -669,7 +669,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Excercise 3"
+    "### Exercise 3"
    ]
   },
   {


### PR DESCRIPTION
The word "exercise" has been spelled wrongly as "excercise" in some instances. This PR fixes it.