### PR TITLE
Mock remote HTTP requests

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,3 +13,5 @@ dust_extinction>=0.7
 astro-gala
 dust_extinction>=0.7
 synphot
+flask
+requests

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -11,6 +11,12 @@ from nbconvert.exporters import RSTExporter
 from nbconvert.writers import FilesWriter
 import nbformat
 
+import mocks  # just needs to be imported to run the code
+from mock_server import app, MOCK_SERVER_PORT
+
+# Start a Flask server to intercept and handle remote HTTP requests
+app.run(port=MOCK_SERVER_PORT)
+
 IPYTHON_VERSION = 4
 
 def clean_keyword(kw):

--- a/scripts/mock_server.py
+++ b/scripts/mock_server.py
@@ -1,0 +1,96 @@
+import hashlib
+import os
+import pickle
+from flask import Flask, request
+from urllib.parse import urlsplit, quote, unquote
+import requests
+
+
+MOCK_SERVER_PORT = 8001
+MOCK_SERVER = 'http://localhost:{port}'.format(port=MOCK_SERVER_PORT)
+
+app = Flask(__name__)
+
+this_path = os.path.split(os.path.abspath(__file__))[0]
+cache_path = os.path.abspath(os.path.join(this_path, '..', 'cache'))
+os.makedirs(cache_path, exist_ok=True)
+
+
+def pack_url(url):
+    scheme, rest = url.split('//')
+    return os.path.join(quote(scheme), rest)
+
+
+def unpack_url(url):
+    scheme, *rest = url.split('/')
+    return '{}//{}'.format(unquote(scheme), '/'.join(rest))
+
+
+def get_cache_filename(cache_key):
+    m = hashlib.md5()
+    for k in cache_key:
+        k = str(k).encode('utf-8')
+        m.update(k)
+    cache_hash = m.hexdigest()
+    return os.path.join(cache_path, cache_hash)
+
+
+def get_post_content(cache_filename, post_data):
+    if not os.path.exists(cache_filename):
+        split = urlsplit(request.url)
+        orig_url = unpack_url(split.path[1:])
+        resp = requests.post(orig_url, data=post_data)
+        content = resp.content
+
+        with open(cache_filename, 'wb') as f:
+            pickle.dump(content, f)
+
+    else:
+        with open(cache_filename, 'rb') as f:
+            content = pickle.load(f)
+
+    return content
+
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>', methods=['GET', 'POST'])
+def get_cached_remote(path):
+
+    if request.data:  # POST
+        cache_key = (path, request.data)
+        cache_filename = get_cache_filename(cache_key)
+        content = get_post_content(cache_filename, request.data)
+
+    elif request.json:  # POST
+        cache_key = (path, request.json)
+        cache_filename = get_cache_filename(cache_key)
+        content = get_post_content(cache_filename, request.json)
+
+    elif request.form:  # POST
+        cache_key = (path, request.form)
+        cache_filename = get_cache_filename(cache_key)
+        content = get_post_content(cache_filename, request.values)
+
+    else:  # assume GET
+        cache_key = (path, request.args)
+        cache_filename = get_cache_filename(cache_key)
+
+        print('here', cache_filename)
+        if not os.path.exists(cache_filename):
+            split = urlsplit(request.url)
+            orig_url = unpack_url('{}?{}'.format(split.path[1:], split.query))
+            resp = requests.get(orig_url)
+            content = resp.content
+
+            with open(cache_filename, 'wb') as f:
+                pickle.dump(content, f)
+
+        else:
+            with open(cache_filename, 'rb') as f:
+                content = pickle.load(f)
+
+    return content
+
+
+if __name__ == '__main__':
+    app.run(port=MOCK_SERVER_PORT)

--- a/scripts/mocks.py
+++ b/scripts/mocks.py
@@ -1,0 +1,106 @@
+from urllib.parse import urljoin
+from mock_server import pack_url, MOCK_SERVER
+
+# ----------------------------------------------------------------------------
+# astropy:
+
+# download_file
+from astropy.utils.data import download_file
+import astropy.utils.data
+
+def mock_download_file(remote_url, *args, **kwargs):
+    return download_file(urljoin(MOCK_SERVER, pack_url(remote_url)),
+                         *args, **kwargs)
+
+astropy.utils.data.download_file = mock_download_file
+
+
+# name resolve / Sesame
+from astropy.coordinates.name_resolve import sesame_url
+import astropy.coordinates.name_resolve
+
+class MockSesameUrl(sesame_url):
+    _value = [urljoin(MOCK_SERVER, pack_url(sesame_url._value[0]))]
+
+astropy.coordinates.name_resolve.sesame_url = MockSesameUrl
+
+# ----------------------------------------------------------------------------
+# astroquery:
+
+# simbad
+from astroquery.simbad import SimbadClass
+import astroquery.simbad
+
+class MockSimbadClass(SimbadClass):
+    SIMBAD_URL = urljoin(MOCK_SERVER, pack_url(SimbadClass.SIMBAD_URL))
+
+astroquery.simbad.SimbadClass = MockSimbadClass
+astroquery.simbad.Simbad = astroquery.simbad.SimbadClass()
+
+
+# esasky
+from astroquery.esasky import ESASkyClass
+import astroquery.esasky
+
+class MockESASkyClass(ESASkyClass):
+    URLbase = urljoin(MOCK_SERVER, pack_url(ESASkyClass.URLbase))
+
+astroquery.esasky.ESASkyClass = MockESASkyClass
+astroquery.esasky.ESASky = MockESASkyClass()
+
+
+# vizier
+import astroquery.vizier
+
+astroquery.vizier.Vizier.VIZIER_SERVER = urljoin(
+    MOCK_SERVER,
+    pack_url('http://' + astroquery.vizier.Vizier.VIZIER_SERVER)).split('//')[1]
+
+
+# conesearch
+from urllib.parse import urljoin
+from mocks import MOCK_SERVER, pack_url
+from astroquery.query import BaseQuery
+from astroquery.vo_conesearch import conf
+from astroquery.vo_conesearch.core import ConeSearchClass
+import astroquery.vo_conesearch.core
+
+class MockConeSearchClass(ConeSearchClass):
+    URL = urljoin(MOCK_SERVER, pack_url(ConeSearchClass.URL))
+
+    def __init__(self):
+        BaseQuery.__init__(self)
+
+astroquery.vo_conesearch.core.ConeSearchClass = MockConeSearchClass
+conf.vos_baseurl = urljoin(MOCK_SERVER, pack_url(conf.vos_baseurl))
+conf.fallback_url = urljoin(MOCK_SERVER, pack_url(conf.fallback_url))
+
+
+from astroquery.vo_conesearch.vos_catalog import VOSDatabase
+import astroquery.vo_conesearch.vos_catalog
+
+class MockVOSDatabase(VOSDatabase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        new_keys = dict()
+        for k in self._url_keys:
+            new_keys[urljoin(MOCK_SERVER, pack_url(k))] = self._url_keys[k]
+        self._url_keys = new_keys
+
+        for k, cat in self._catalogs.items():
+            cat['url'] = urljoin(MOCK_SERVER, pack_url(cat['url']))
+
+astroquery.vo_conesearch.vos_catalog.VOSDatabase = MockVOSDatabase
+
+# mast
+
+# TODO: mast mocking doesn't work because it is more complicated. The requests
+# have a randomly generated number in them, so we can't create a hash based on
+# the request parameters as is done in mock_server.py
+
+# from astroquery.mast import conf, ObservationsClass
+# import astroquery.mast
+# conf.server = urljoin(MOCK_SERVER, pack_url(conf.server))
+# astroquery.mast.Observations = ObservationsClass()


### PR DESCRIPTION
This is a silly and somewhat crazy step towards dealing with our constantly failing circleCI builds that require firing off a bunch of remote HTTP requests (I'm looking at you, `vo_conesearch`). Here I've "mocked" a bunch of the astroquery and astropy classes and functions that make remote requests (which don't universally support caching) to instead point at localhost, and I've created a local http server to catch the requests and either (1) return results from a cache, or (2) pass the request through to the external site and then cache the results for the future. In principle, we could then add `~/.astropy/cache` along with this custom cache to be persistent data stores on circleCI (https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/). 

This is a somewhat brittle system, and would require fiddling if/when the astroquery API changes, so I'm not sure we actually want to do this...