### PR TITLE
Add install instructions for nbstripout

### DIFF
--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -136,3 +136,37 @@ Marking a cell with an intentional error
 Edit the cell metadata of the cell in which you would like to raise an exception
 and add the following to the top-level JSON: ``"tags": ["raises-exception"]``
 This tag is recognized by the latest (master) version of nbconvert.
+
+Automatically strip output and notebook metadata
+------------------------------------------------
+
+Jupyter notebooks contain some metadata that is typically hidden from users,
+which contains, e.g., information about the Python kernel used to run it, the
+version of IPython, etc. When tutorial authors or maintainers edit notebooks,
+this metadata is automatically modified by Jupyter, leading to superfluous and
+sometimes confusing changes to the notebooks when viewed in a "diff" locally or
+on GitHub.
+
+In order to prevent such metadata updates from appearing in pull requests, we
+therefore recommend that any contributor or maintainer install and use
+`nbstripout <https://github.com/kynan/nbstripout>`_ set up with an automatic git
+hook to clean metadata changes whenever a notebook change is committed to your
+local repo. To install ``nbstripout``, first pip install it with:
+
+    pip install nbstripout
+
+This repo is already configured Then, you have to configure git within your
+local clone of astropy-tutorials to tell ``nbstripout`` to intervene whenever
+you commit changes in the repo. To do this, you first have to "install" it with
+
+    nbstripout --install
+
+Then, to tell ``nbstripout`` to ignore metadata changes, you must also run
+
+    git config filter.nbstripout.extrakeys '
+        metadata.celltoolbar metadata.kernel_spec.display_name
+        metadata.kernel_spec.name metadata.language_info.codemirror_mode.version
+        metadata.language_info.pygments_lexer metadata.language_info.version
+        metadata.toc metadata.notify_time metadata.varInspector
+        cell.metadata.heading_collapsed cell.metadata.hidden
+        cell.metadata.code_folding cell.metadata.tags cell.metadata.init_cell'

--- a/tutorials/dev.rst
+++ b/tutorials/dev.rst
@@ -137,11 +137,11 @@ Edit the cell metadata of the cell in which you would like to raise an exception
 and add the following to the top-level JSON: ``"tags": ["raises-exception"]``
 This tag is recognized by the latest (master) version of nbconvert.
 
-Automatically strip output and notebook metadata
+Automatically Strip Output and Notebook Metadata
 ------------------------------------------------
 
 Jupyter notebooks contain some metadata that is typically hidden from users,
-which contains, e.g., information about the Python kernel used to run it, the
+which contains, for example, information about the Python kernel used to run it, the
 version of IPython, etc. When tutorial authors or maintainers edit notebooks,
 this metadata is automatically modified by Jupyter, leading to superfluous and
 sometimes confusing changes to the notebooks when viewed in a "diff" locally or
@@ -149,19 +149,19 @@ on GitHub.
 
 In order to prevent such metadata updates from appearing in pull requests, we
 therefore recommend that any contributor or maintainer install and use
-`nbstripout <https://github.com/kynan/nbstripout>`_ set up with an automatic git
+`nbstripout <https://github.com/kynan/nbstripout>`_ set up with an automatic Git
 hook to clean metadata changes whenever a notebook change is committed to your
 local repo. To install ``nbstripout``, first pip install it with:
 
     pip install nbstripout
 
-This repo is already configured Then, you have to configure git within your
+This repo is already configured. Next, configure Git within your
 local clone of astropy-tutorials to tell ``nbstripout`` to intervene whenever
-you commit changes in the repo. To do this, you first have to "install" it with
+you commit changes in the repo. To do this, you first have to "install" it with:
 
     nbstripout --install
 
-Then, to tell ``nbstripout`` to ignore metadata changes, you must also run
+Then, to tell ``nbstripout`` to ignore metadata changes, you must also run:
 
     git config filter.nbstripout.extrakeys '
         metadata.celltoolbar metadata.kernel_spec.display_name


### PR DESCRIPTION
I added some text to the developer documentation about how to install `nbstripout`: I think we should all be using this, at least within this repo, to avoid committing notebook output and metadata changes. We should also point contributors to this section if they opt to use the GitHub contribution method.

Tagging everyone so you install it yourself!
@eteq @kelle @eblur @kakirastern @MananAgarwal @lglattly 