### PR TITLE
Removing broken link from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,15 +24,6 @@ your web browser within a remote server:
 .. image:: http://mybinder.org/badge.svg
     :target: https://mybinder.org/v2/gh/astropy/astropy-tutorials/master?filepath=tutorials/notebooks
 
-
-Contributing tutorial material
-------------------------------
-
-Please see the "`For contributors
-<http://www.astropy.org/astropy-tutorials/#for-contributors>`_" section
-of the tutorials documentation for information on how to get started.
-
-
 Tutorial infrastructure
 -----------------------
 


### PR DESCRIPTION
The link to http://www.astropy.org/astropy-tutorials/#for-contributors no longer works, simply removing it from the README. The subsequent link on the page still works and serves the same purpose.