### PR TITLE
Pin nbconvert version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,7 @@ pip-run: &pip-install
     . venv/bin/activate
     pip install -r pip-requirements.txt
     pip install sphinx pytest
-    pip install sphinx-astropy sphinx-bootstrap-theme
-    pip install git+https://github.com/jupyter/nbconvert
+    pip install sphinx-astropy sphinx-bootstrap-theme nbconvert==5.6.1
 
 jobs:
 


### PR DESCRIPTION
We previously installed the dev version, but the circleci build is now failing, possible due to changes in the dev version. I haven't been able to reproduce the failures locally, so this is to try pinning the nbconvert version.