### PR TITLE
Modify code in attempt to fix image display issue on web

### DIFF
--- a/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
+++ b/tutorials/notebooks/Coordinates-Intro/Coordinates-Intro.ipynb
@@ -16,7 +16,7 @@
     "* Use a `SkyCoord` object to query a database\n",
     "\n",
     "## Keywords\n",
-    "coordinates, OOP, file input/output\n",
+    "coordinates, OOP, file input/output (i/o)\n",
     "\n",
     "\n",
     "## Summary\n",
@@ -248,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Image('HCG7_SDSS_cutout.jpg')"
+    "Image('./HCG7_SDSS_cutout.jpg')"
    ]
   },
   {


### PR DESCRIPTION
Now the image for the "Coords 1: Getting Started with astropy.coordinates" is not showing: 

<img width="1440" alt="Screenshot 2020-03-07 23 23 31" src="https://user-images.githubusercontent.com/26264600/76146771-96f00d80-60d0-11ea-9b6a-a647b3370958.png">

<img width="1440" alt="Screenshot 2020-03-08 00 06 20" src="https://user-images.githubusercontent.com/26264600/76146776-a7a08380-60d0-11ea-9b4c-c417d06e8794.png">

So am trying a simple trick to make image show as intended. 