### PR TITLE
Use pip requirements in anaconda environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ pip-run: &pip-install
   command: |
     python3 -m venv venv
     . venv/bin/activate
-    pip install -r pip-requirements.txt
-    pip install sphinx pytest
-    pip install sphinx-astropy sphinx-bootstrap-theme nbconvert==5.6.1
+    pip install -r pip-requirements.txt  --progress-bar off
+    pip install --progress-bar off sphinx pytest
+    pip install --progress-bar off sphinx-astropy sphinx-bootstrap-theme nbconvert==5.6.1
 
 jobs:
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,16 +4,7 @@ channels:
   - astropy
 
 dependencies:
-  - python=3.6
-  - IPython=6.1.0
-  - astropy=3
-  - astroquery>=0.3.7
-  - matplotlib==3.0.2
-  - numpy=1.14
-  - scipy=1.0 # needed for coordinates cross-matching
-  - jupyter=1.0
-  - notebook>=5.7.2
-  - aplpy # used in FITS-cube tutorial
-  - spectral-cube # used in FITS-cube tutorial
-  - reproject # used in FITS-cube tutorial
-  - dust_extinction>=0.7
+  - python=3.7
+  - pip
+  - pip:
+    - -r pip-requirements.txt

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -8,7 +8,7 @@ scipy>=1.0
 notebook>=5.7.2
 aplpy
 spectral-cube
-reproject
+reproject==0.5.1
 dust_extinction>=0.7
 astro-gala
 dust_extinction>=0.7


### PR DESCRIPTION
- Use the pip requirements in the anaconda environment file (to avoid duplication)
- Pinned reproject because with astropy 4.0.1 and reproject 0.6, we are unable to import reproject:

```
KeyErrorTraceback (most recent call last)
<ipython-input-1-5087be31c7cf> in <module>
     15 from astroquery.utils import TableList
     16 from astropy.wcs import WCS
---> 17 from reproject import reproject_interp

~/project/venv/lib/python3.7/site-packages/reproject/__init__.py in <module>
     11 
     12 if not _ASTROPY_SETUP_:  # noqa
---> 13     from .interpolation import reproject_interp  # noqa
     14     from .spherical_intersect import reproject_exact  # noqa
     15     from .healpix import reproject_from_healpix, reproject_to_healpix  # noqa

~/project/venv/lib/python3.7/site-packages/reproject/interpolation/__init__.py in <module>
      3 Routines to carry out reprojection by interpolation.
      4 """
----> 5 from .high_level import *  # noqa

~/project/venv/lib/python3.7/site-packages/reproject/interpolation/high_level.py in <module>
     17 @deprecated_renamed_argument('independent_celestial_slices', None, since='0.6')
     18 def reproject_interp(input_data, output_projection, shape_out=None, hdu_in=0,
---> 19                      order='bilinear', output_array=None, return_footprint=True):
     20     """
     21     Reproject data to a new projection using interpolation (this is typically

~/project/venv/lib/python3.7/site-packages/astropy/utils/decorators.py in decorator(function)
    441             else:
    442                 if new_name[i] is None:
--> 443                     param = arguments[old_name[i]]
    444                 elif new_name[i] in arguments:
    445                     param = arguments[new_name[i]]

KeyError: 'independent_celestial_slices'
KeyError: 'independent_celestial_slices'
```