### PR TITLE
Update contributing doc to add uploading data files to Zenodo info

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -211,7 +211,10 @@ If your tutorial includes large data files (where large means >~ 1 MB), we don't
 want to include them in the ``astropy/astropy-tutorials`` git repository, as
 that will drastically slow down cloning the repository. Instead, we encourage
 use of the `astropy.utils.download_files` function, and will host data files on
-the `<http://data.astropy.org>`_ server. To do this, use the following
+the `<http://data.astropy.org>`_ server by opening a PR at the
+`<https://github.com/astropy/astropy-data>`_ repository, or to use Zenodo to host the data files
+if the file concerned is larger than 10 MB.
+To do the former, use the following
 procedure:
 
 * When writing your tutorial, include the files in your tutorial's directory
@@ -241,10 +244,30 @@ procedure:
 
   If you do this, the only change necessary when merging your notebook will be to set ``tutorialpath`` to  ``'http://data.astropy.org/tutorials/My-tutorial-name/'``.
 
+For larger data files that are bigger than 10 MB in size, we recommend hosting with Zenodo. Using Zenodo
+to host large data files is very straightforward and involves potentially far less steps. To use
+this approach do the following:
+
+* You will need to sign up for an account with Zenodo before you can upload a file there.
+
+* After a Zenodo account has been properly set up, be sure to log in and do a new upload. Follow
+the Zenodo instructions and complete all the required fields as the bare minimum in order to have
+the data file(s) uploaded to their records. Once this is done you will have a link to share the data.
+
+* With the link which has the format ``https://zenodo.org/api/records/:id``, and the HTTP GET request
+needed to retrieve the record using the Python package ``requests`` is as below::
+
+    import requests
+    r = requests.get("https://zenodo.org/api/records/1234)
+
+Basically to use the output you simply need to add the following lines to your Jupyter notebook::
+
+    with open('./some-data-file.fits', 'wb') as f:
+        f.write(r.content)
+
 If you need information or help with:
 
-* previewing how the rendered Jupyter notebooks will look on the tutorial
-  webpage
+* previewing how the rendered Jupyter notebooks will look on the tutorial webpage
 * marking a cell with an intentional / expected error
 
 please see the :ref:`dev-page`.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -244,9 +244,8 @@ procedure:
 
   If you do this, the only change necessary when merging your notebook will be to set ``tutorialpath`` to  ``'http://data.astropy.org/tutorials/My-tutorial-name/'``.
 
-For larger data files that are bigger than 10 MB in size, we recommend hosting with Zenodo. Using Zenodo
-to host large data files is very straightforward and involves potentially far less steps. To use
-this approach do the following:
+For larger data files that are bigger than 10 MB in size, we recommend hosting with Zenodo. 
+To use this approach, follow these steps:
 
 * You will need to sign up for an account with Zenodo before you can upload a file there.
 
@@ -254,13 +253,12 @@ this approach do the following:
 the Zenodo instructions and complete all the required fields as the bare minimum in order to have
 the data file(s) uploaded to their records. Once this is done you will have a link to share the data.
 
-* With the link which has the format ``https://zenodo.org/api/records/:id``, and the HTTP GET request
-needed to retrieve the record using the Python package ``requests`` is as below::
+* With the link to the data file record, which has the format ``https://zenodo.org/api/records/:id``, an example HTTP GET request needed to retrieve the data using the Python package ``requests`` is shown below::
 
     import requests
     r = requests.get("https://zenodo.org/api/records/1234)
 
-Basically to use the output you simply need to add the following lines to your Jupyter notebook::
+To use the output as a locally stored file, you would first need to write the file contents to a file, for example::
 
     with open('./some-data-file.fits', 'wb') as f:
         f.write(r.content)

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -7,7 +7,8 @@ jupyter>=1.0
 scipy>=1.0
 notebook>=5.7.2
 aplpy
-spectral-cube
+git+https://github.com/radio-astro-tools/spectral-cube.git#egg=spectral-cube
+git+https://github.com/radio-astro-tools/radio-beam.git#egg=radio-beam
 reproject==0.5.1
 dust_extinction>=0.7
 astro-gala


### PR DESCRIPTION
Fixes #454.

Add info to the `CONTRIBUTING.rst` file to add info regarding how to use Zenodo to host large data files plus code snippets that may be needed for this approach to supplement the existing large data file uploading mechanism with http://www.astropy.org/astropy-data/ or http://data.astropy.org. 