### PR TITLE
Add repository-dispatch workflow to deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,21 @@ jobs:
         run: |
           nbcollection convert --flatten --build-path=. -v --make-index --index-template=templates/index.tpl tutorials --exclude=conesearch  # TODO: remove this exclude!
 
+      - name: Name artifact
+        id: nameartifact
+        run: |
+          echo "::set-output name=artifactName::rendered-tutorials-${{ github.sha }}"
+
       - uses: actions/upload-artifact@v2
         with:
-          name: rendered-tutorials-${{ github.sha }}
+          name: ${{ steps.nameartifact.outputs.artifactName }}
           path: _build
+
+      - name: Dispatch Learn Astropy deployment
+        uses: peter-evans/repository-dispatch@v1
+        if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
+        with:
+          token: ${{ secrets.DISPATCH_GITHUB_TOKEN }}
+          repository: astropy/learn-astropy
+          event-type: tutorials-build
+          client-payload: '{"artifactName": "${{ steps.nameartifact.outputs.artifactName }}", "checkrunid": "${{ github.run_id }}", "repo": "${{ github.repository }}"}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           path: _build
 
       - name: Dispatch Learn Astropy deployment
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@0e8ca8c8a5ca5e28d25af2c27fc5aa40f16cffca
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
         with:
           token: ${{ secrets.DISPATCH_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a "repository dispatch" step to the build workflow. What this does is trigger a GitHub Actions run in the astropy/learn-astropy repository. The payload for the trigger includes a reference to the workflow artifact, which will allow the learn-astropy build to download the tutorials artifact.

This requires a GitHub Secret to be set up on the tutorials repo named `DISPATCH_GITHUB_TOKEN` that has write access to the astropy/learn-astropy repository. See https://github.com/peter-evans/repository-dispatch#token