### PR TITLE
Make the artifact's name fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,4 +56,4 @@ jobs:
           token: ${{ secrets.DISPATCH_GITHUB_TOKEN }}
           repository: astropy/learn-astropy
           event-type: tutorials-build
-          client-payload: '{"artifactName": "${{ steps.nameartifact.outputs.artifactName }}", "checkrunid": "${{ github.run_id }}", "repo": "${{ github.repository }}"}'
+          client-payload: '{"artifactName": "${{ steps.nameartifact.outputs.artifactName }}", "runid": "${{ github.run_id }}", "repo": "${{ github.repository }}"}'


### PR DESCRIPTION
This change makes it just a bit easier and more consistent to programmatically get the right artifact even when the learn-astropy repo is being built against the latest tutorials build (as opposed to a dispatch trigger where the artifact's name is included in the webhook payload). The downside is that the artifact isn't conveniently versioned when a developer downloads the artifact directly.