### PR TITLE
Fix pip install instructions for gala

### DIFF
--- a/tutorials/gaia-galactic-orbits/gaia-galactic-orbits.ipynb
+++ b/tutorials/gaia-galactic-orbits/gaia-galactic-orbits.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "This tutorial depends on the Astropy affiliated packages `gala` and `astroquery`. Both of these packages can be pip-installed with:\n",
     "\n",
-    "    pip install astro-gala astroquery"
+    "    pip install gala astroquery"
    ]
   },
   {


### PR DESCRIPTION
Removed the old package name `astro-gala` -> `gala`