### PR TITLE
Remove CNAME (to move to learn-astropy)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-learn.astropy.org


### PR DESCRIPTION
This PR removes the CNAME, as a companion to a PR I'm about to create in astropy/learn-astropy . Together these should have the effect of making learn.astropy.org point to learn-astropy instead of astropy-tutorials.

Note this is ready as-is but should *not* be merged until I've completed the verification process, and then should be merged *before* the follow-on PR (I think...).

cc @adrn @jonathansick @kelle 