### PR TITLE
Enabled ExtractOutputPreprocessor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Convert the notebooks to HTML
         run: |
-          nbcollection convert --flatten --build-path=. -v --make-index --index-template=templates/index.tpl tutorials --exclude=conesearch  # TODO: remove this exclude!
+          nbcollection convert --flatten --build-path=. -v --make-index --preprocessors=nbconvert.preprocessors.ExtractOutputPreprocessor --index-template=templates/index.tpl tutorials --exclude=conesearch  # TODO: remove this exclude!
 
       - name: Name artifact
         id: nameartifact


### PR DESCRIPTION
This preprocessor moves figures out of the HTML output. They should still upload normally to GitHub Pages though because we capture and upload the build artifact as a whole directory rather than file-by-file.