### PR TITLE
Only run modified notebooks in PRs, with an optional label override

### DIFF
--- a/.github/get_modified_tutorials.py
+++ b/.github/get_modified_tutorials.py
@@ -1,0 +1,24 @@
+import sys
+from git import Repo
+
+
+def main(repo_path):
+    r = Repo(repo_path)
+
+    # NOTE: assumes the main branch is named "main"
+    files_changed = r.git.diff(
+        f'{str(r.active_branch)}..main',
+        '--name-only').split("\n")
+    files_changed = [f for f in files_changed if f.endswith('.ipynb')]
+    print(" ".join(files_changed))
+
+
+if __name__ == "__main__":
+    try:
+        repo_path = sys.argv[1]
+    except IndexError:
+        print("ERROR: did not receive a repo path.\n"
+              "Usage: get_modified_tutorials.py <ROOT TUTORIALS REPO PATH>")
+        sys.exit(1)
+
+    main(repo_path)

--- a/.github/get_modified_tutorials.py
+++ b/.github/get_modified_tutorials.py
@@ -10,7 +10,8 @@ def main(repo_path):
         f'{str(r.head.object.hexsha)}..origin/main',
         '--name-only').split("\n")
     files_changed = [f for f in files_changed if f.endswith('.ipynb')]
-    print(" ".join(files_changed))
+    if files_changed:
+        print(" ".join(files_changed))
 
 
 if __name__ == "__main__":

--- a/.github/get_modified_tutorials.py
+++ b/.github/get_modified_tutorials.py
@@ -7,7 +7,7 @@ def main(repo_path):
 
     # NOTE: assumes the main branch is named "main"
     files_changed = r.git.diff(
-        f'{str(r.active_branch)}..main',
+        f'{str(r.head.object.hexsha)}..origin/main',
         '--name-only').split("\n")
     files_changed = [f for f in files_changed if f.endswith('.ipynb')]
     print(" ".join(files_changed))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   release:
     types:
       - published
+  schedule:
+    - cron: "0 10 * * 1"  # Mondays @ 6AM Eastern
 
 jobs:
   notebooks:
@@ -16,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run all tutorials
         if: contains(github.event.pull_request.labels.*.name, 'Run all tutorials')
         run: |
-          nbcollection execute --timeout=600 --flatten --build-path=. -v tutorials --exclude=conesearch  # TODO: remove this exclude!
           echo "TUTORIALS=tutorials" >> $GITHUB_ENV
 
       # Otherwise, only run tutorials that have been modified
@@ -44,9 +43,14 @@ jobs:
         run: |
           MODIFIED="$(python .github/get_modified_tutorials.py .)"
           echo "Modified tutorials: $MODIFIED"
-          nbcollection execute --timeout=600 --flatten --build-path=. -v $MODIFIED
           echo "TUTORIALS=$MODIFIED" >> $GITHUB_ENV
 
+      - name: Execute the tutorials
+        if: env.TUTORIALS != ''
+        run: |
+          nbcollection execute --timeout=600 --flatten --build-path=. -v ${{ env.TUTORIALS }}
+
       - name: Convert the notebooks to HTML
+        if: env.TUTORIALS != ''
         run: |
           nbcollection convert --flatten --build-path=. -v --make-index --index-template=templates/index.tpl ${{ env.TUTORIALS }}

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Run only modified tutorials
         if: "!contains(github.event.pull_request.labels.*.name, 'Run all tutorials')"
         run: |
-          python .github/get_modified_tutorials.py . # testing
           MODIFIED="$(python .github/get_modified_tutorials.py .)"
+          echo "Modified tutorials: $MODIFIED"
           nbcollection execute --timeout=600 --flatten --build-path=. -v $MODIFIED
           echo "TUTORIALS=$MODIFIED" >> $GITHUB_ENV
 

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -1,0 +1,52 @@
+name: Build tutorials (pull requests)
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      # We also want this workflow triggered if the 'Run all tutorials' label
+      # is added or present when PR is updated
+      - synchronize
+      - labeled
+
+jobs:
+  notebooks:
+    name: "Execute and convert the notebooks to HTML"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install pandoc
+          python -m pip install -U pip
+          python -m pip install -r pip-requirements.txt
+          python -m pip install gitpython
+          python -m pip install git+https://github.com/astropy/nbcollection
+
+      # Run all tutorials if the label is present
+      - name: Run all tutorials
+        if: contains(github.event.pull_request.labels.*.name, 'Run all tutorials')
+        run: |
+          nbcollection execute --timeout=600 --flatten --build-path=. -v tutorials --exclude=conesearch  # TODO: remove this exclude!
+          echo "TUTORIALS=tutorials" >> $GITHUB_ENV
+
+      # Otherwise, only run tutorials that have been modified
+      - name: Run only modified tutorials
+        if: "!contains(github.event.pull_request.labels.*.name, 'Run all tutorials')"
+        run: |
+          python .github/get_modified_tutorials.py . # testing
+          MODIFIED="$(python .github/get_modified_tutorials.py .)"
+          nbcollection execute --timeout=600 --flatten --build-path=. -v $MODIFIED
+          echo "TUTORIALS=$MODIFIED" >> $GITHUB_ENV
+
+      - name: Convert the notebooks to HTML
+        run: |
+          nbcollection convert --flatten --build-path=. -v --make-index --index-template=templates/index.tpl ${{ env.TUTORIALS }}


### PR DESCRIPTION
Refreshing some of the CI config files so that, by default, PR builds only run notebooks that have been modified.

Note: This currently contains a test commit that modifies two notebooks, as a test of the new github actions workflow. That commit should be removed before merging, if this works!

Fixes #519 