### PR TITLE
fix use of weights in fitting tutorial

### DIFF
--- a/tutorials/Models-Quick-Fit/Models-Quick-Fit.ipynb
+++ b/tutorials/Models-Quick-Fit/Models-Quick-Fit.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we give to our **fitter** (method to fit the data) the **model** and the **data** to perform the fit. Note that we are including weights: This means that values with higher error will have smaller weight (less importance) in the fit, and the contrary for data with smaller errors. This way of fitting is called *Weighted Linear Least Squares* and you can find more information about it [here](https://www.mathworks.com/help/curvefit/least-squares-fitting.html) or [here](https://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares). Note that the fitting routine takes weights as 1/error and squares them for you, which is different from the definition of weights used on the linked pages."
+    "Finally, we give to our **fitter** (method to fit the data) the **model** and the **data** to perform the fit. Note that we are including weights: This means that values with higher error will have smaller weight (less importance) in the fit, and the contrary for data with smaller errors. This way of fitting is called *Weighted Linear Least Squares* and you can find more information about it [here](https://www.mathworks.com/help/curvefit/least-squares-fitting.html) or [here](https://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares). Note that the fitting routine takes weights as 1/error and squares them for you, as indicated [in the description of the function](https://docs.astropy.org/en/stable/api/astropy.modeling.fitting.LinearLSQFitter.html)."
    ]
   },
   {
@@ -766,14 +766,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython"
+    "name": "ipython",
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/Models-Quick-Fit/Models-Quick-Fit.ipynb
+++ b/tutorials/Models-Quick-Fit/Models-Quick-Fit.ipynb
@@ -766,22 +766,14 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
+    "name": "ipython"
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "nbconvert_exporter": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/Models-Quick-Fit/Models-Quick-Fit.ipynb
+++ b/tutorials/Models-Quick-Fit/Models-Quick-Fit.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we give to our **fitter** (method to fit the data) the **model** and the **data** to perform the fit. Note that we are including weights: This means that values with higher error will have smaller weight (less importance) in the fit, and the contrary for data with smaller errors. This way of fitting is called *Weighted Linear Least Squares* and you can find more information about it [here](https://www.mathworks.com/help/curvefit/least-squares-fitting.html) or [here](https://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares)."
+    "Finally, we give to our **fitter** (method to fit the data) the **model** and the **data** to perform the fit. Note that we are including weights: This means that values with higher error will have smaller weight (less importance) in the fit, and the contrary for data with smaller errors. This way of fitting is called *Weighted Linear Least Squares* and you can find more information about it [here](https://www.mathworks.com/help/curvefit/least-squares-fitting.html) or [here](https://en.wikipedia.org/wiki/Least_squares#Weighted_least_squares). Note that the fitting routine takes weights as 1/error and squares them for you, which is different from the definition of weights used on the linked pages."
    ]
   },
   {
@@ -227,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_fit = fitter(model, log_period, k_mag, weights=1.0/k_mag_err**2)\n",
+    "best_fit = fitter(model, log_period, k_mag, weights=1.0/k_mag_err)\n",
     "print(best_fit)"
    ]
   },
@@ -348,7 +348,7 @@
    "source": [
     "model_poly = models.Polynomial1D(degree=3)\n",
     "fitter_poly = fitting.LinearLSQFitter() \n",
-    "best_fit_poly = fitter_poly(model_poly, x1, y1, weights = 1.0/y1_err**2)"
+    "best_fit_poly = fitter_poly(model_poly, x1, y1, weights = 1.0/y1_err)"
    ]
   },
   {
@@ -374,7 +374,7 @@
    "outputs": [],
    "source": [
     "fitter_poly_2 = fitting.SimplexLSQFitter()\n",
-    "best_fit_poly_2 = fitter_poly_2(model_poly, x1, y1, weights = 1.0/y1_err**2)"
+    "best_fit_poly_2 = fitter_poly_2(model_poly, x1, y1, weights = 1.0/y1_err)"
    ]
   },
   {
@@ -538,7 +538,7 @@
    "source": [
     "model_gauss = models.Gaussian1D()\n",
     "fitter_gauss = fitting.LevMarLSQFitter()\n",
-    "best_fit_gauss = fitter_gauss(model_gauss, x2, y2, weights=1/y2_err**2)"
+    "best_fit_gauss = fitter_gauss(model_gauss, x2, y2, weights=1/y2_err)"
    ]
   },
   {
@@ -766,14 +766,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
-    "name": "ipython"
+    "name": "ipython",
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- [ X] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [X ] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [ X] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.

I changed all instances of `weights = 1.0/error**2` to `weights = 1.0/error` to address #570.