### PR TITLE
Unpin pyvo dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ reproject
 dust_extinction
 gala
 synphot
-pyvo==1.2.0
+pyvo
 pvextractor


### PR DESCRIPTION
@adrn 

This PR removes a pin on the `pyvo` dependency.

The dependency is currently pinned to `pyvo==1.2.0`. This is causing several notebook executions to fail because of a call to the deprecated `from astropy.utils.decorators import wraps` from within `pyvo 1.2.0`. From version `1.2.1` onward, `pyvo` instead uses `from functools import partial, wraps` [(pyvo changelog)](https://github.com/astropy/pyvo/blob/89671523011fc6b49f2205ac4a9afd5a43c03025/CHANGES.rst#121-2022-01-12). 

Unpinning `1.2.0` may break something else, but there's no comment in `requirements.txt` as to why it's pinned, so this is a first step to get the notebooks to execute.

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.
