### PR TITLE
[WIP] Use individual notebook requirements

### DIFF
--- a/tutorials/astropy-coordinates/requirements.txt
+++ b/tutorials/astropy-coordinates/requirements.txt
@@ -1,0 +1,4 @@
+astropy
+astroquery
+matplotlib
+numpy

--- a/tutorials/position-velocity-diagrams/requirements.txt
+++ b/tutorials/position-velocity-diagrams/requirements.txt
@@ -1,0 +1,5 @@
+astropy
+numpy
+pvextractor
+pylab
+spectral_cube

--- a/tutorials/spectral-cube-reprojection/requirements.txt
+++ b/tutorials/spectral-cube-reprojection/requirements.txt
@@ -1,0 +1,5 @@
+astropy
+dask
+numpy
+radio_beam
+spectral-cube


### PR DESCRIPTION
Removes the top-level `requirements.txt` in favor of individual `requirements.txt` specified in each folder in `tutorials`.

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.
