### PR TITLE
CI: replace deprecated set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Name artifact
         id: nameartifact
         run: |
-          echo "::set-output name=artifactName::rendered-tutorials"
-
+          echo "::set-output {artifactName}::{rendered-tutorials}" >> $GITHUB_OUTPUT
+          
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.nameartifact.outputs.artifactName }}


### PR DESCRIPTION
CI: replace deprecated `set-output` command in `build.yml` -- see [github blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.
