### PR TITLE
workflow action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           path: _build
 
       - name: Dispatch Learn Astropy deployment
-        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588
+        uses: peter-evans/repository-dispatch@v3
         if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') && (github.repository == 'astropy/astropy-tutorials')}}
         with:
           token: ${{ secrets.DISPATCH_GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the version of 'peter-evans/repository-dispatch' in the `build.yml` workflow.

The workflow is currently failing due to 'Bad credentials' - the `secrets.DISPATCH_GITHUB_TOKEN` likely needs to be updated. I don't have permissions to edit the repo secrets. 

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.
