### PR TITLE
Binder dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ convertall:
 	for notebook in ${ALL_NOTEBOOKS}; do \
 		echo Installing requirements from $${_paths[i]}; \
 		python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
-		nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
+		nbcollection convert --blah ${CONVERTFLAGS} ${FLAGS} $$notebook; \
 		i=$$((i+1)); \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ convert:
 	_paths=($(MODIFIED_RQT_PATHS)); \
 	for notebook in ${MODIFIED_NOTEBOOKS}; do \
 		echo Installing requirements from $${_paths[i]}; \
-		python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
-		nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
+		! python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
+		! nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
 		i=$$((i+1)); \
 	done
 
@@ -57,8 +57,8 @@ convertall:
 	_paths=($(ALL_RQT_PATHS)); \
 	for notebook in ${ALL_NOTEBOOKS}; do \
 		echo Installing requirements from $${_paths[i]}; \
-		python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
-		nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
+		! python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
+		! nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
 		i=$$((i+1)); \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ init:
 build: convert
 buildall: convertall
 
+# 'set -e' is used to cause the bash loop to immediately exit on a failure.
+# without this, the github actions workflow can succeed even if commands in these
+# bash loops (installing packages, executing notebooks, converting notebooks) fail
 execute:
+	set -e; \
 	i=0; \
 	_paths=($(MODIFIED_RQT_PATHS)); \
 	for notebook in ${MODIFIED_NOTEBOOKS}; do \
@@ -44,6 +48,7 @@ convert:
 	done
 
 executeall:
+	set -e; \
 	i=0; \
 	_paths=(${ALL_RQT_PATHS}); \
 	for notebook in ${ALL_NOTEBOOKS}; do \
@@ -54,6 +59,7 @@ executeall:
 	done
 
 convertall:
+	set -e; \
 	i=0; \
 	_paths=($(ALL_RQT_PATHS)); \
 	for notebook in ${ALL_NOTEBOOKS}; do \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CONVERTFLAGS = --make-index --preprocessors=nbconvert.preprocessors.ExtractOutpu
 init:
 	python -m pip install -U -r requirements-dev.txt
 
+# nbcollection 'convert' also runs 'execute', so just calling 'convert' here
 build: convert
 buildall: convertall
 

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,13 @@ execute:
 	done
 
 convert:
+	set -e; \
 	i=0; \
 	_paths=($(MODIFIED_RQT_PATHS)); \
 	for notebook in ${MODIFIED_NOTEBOOKS}; do \
 		echo Installing requirements from $${_paths[i]}; \
-		! python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
-		! nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
+		python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
+		nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
 		i=$$((i+1)); \
 	done
 
@@ -57,8 +58,8 @@ convertall:
 	_paths=($(ALL_RQT_PATHS)); \
 	for notebook in ${ALL_NOTEBOOKS}; do \
 		echo Installing requirements from $${_paths[i]}; \
-		! python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
-		! nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
+		python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
+		nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
 		i=$$((i+1)); \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ convertall:
 	for notebook in ${ALL_NOTEBOOKS}; do \
 		echo Installing requirements from $${_paths[i]}; \
 		python -m pip install --force-reinstall -r $${_paths[i]} > /dev/null; \
-		nbcollection convert --blah ${CONVERTFLAGS} ${FLAGS} $$notebook; \
+		nbcollection convert ${CONVERTFLAGS} ${FLAGS} $$notebook; \
 		i=$$((i+1)); \
 	done
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ more structured and exhaustive view of the Astropy core package.
 To see the tutorials rendered as static web pages, see the [Learn Astropy
 website](https://learn.astropy.org).
 
-To execute the tutorials interactively, either use Google Colab to run the tutorials
+To execute the tutorials interactively, either use Binder to run the tutorials
 remotely or clone this repository to your local machine.
 
 ### Run the tutorials in your browser with Binder

--- a/README.md
+++ b/README.md
@@ -1,61 +1,42 @@
 # Astropy Tutorials
 
 This repository contains tutorial IPython notebooks for the
-[Astropy](http://astropy.org) project. These are typically longer-form, more
+[Astropy](http://astropy.org) project. These are typically longer-form,
 narrative presentations of functionality in the [Astropy core
 package](https://github.com/astropy/astropy) and any [affiliated
-packages](http://www.astropy.org/affiliated/index.html). The tutorials are
-therefore different from the [Astropy core package
-documentation](http://docs.astropy.org), which presents a more structured and
-exhaustive view of the Astropy core package.
+packages](http://www.astropy.org/affiliated/index.html). The tutorials are different
+from the [Astropy core package documentation](http://docs.astropy.org), which presents a
+more structured and exhaustive view of the Astropy core package.
 
 
-## View the tutorials rendered as HTML pages
+## Viewing and running the tutorials
 
 To see the tutorials rendered as static web pages, see the [Learn Astropy
 website](https://learn.astropy.org).
 
-To execute the tutorials interactively, you can either clone this repository to
-your local machine or use Binder to run the tutorials remotely, as described
-below.
+To execute the tutorials interactively, either use Google Colab to run the tutorials
+remotely or clone this repository to your local machine.
 
-
-## Run the tutorials locally
-
-To run the tutorials locally, you should start by cloning this repository with
-`git` or downloading an archive of this repository from GitHub. You will need to
-have [Jupyter notebook](http://jupyter.org/) and IPython installed and will need
-to install the tutorial dependencies specified in `requirements.txt`:
-
-    python -m pip install -r requirements.txt
-
-To check that your environment is set up to run the tutorials, you can use the
-Makefile provided in this repository with the custom `envcheck` command:
-
-    make envcheck
-
-If this line fails, your environment is missing packages, and you should run the
-pip install line shown above.
-
-The notebook files themselves live in the `tutorials` directory of this
-repository, organized by the names of the tutorials. These can be opened with
-Jupyter notebook as with any other notebook files.
-
-
-## Run the tutorials on Binder
-
-You can also get started with a remote environment to run the tutorial notebooks
-in your browser using [Binder](http://mybinder.org)
+### Run the tutorials in your browser with Binder
 
 [![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/astropy/astropy-tutorials/main?filepath=tutorials)
 
+### Run the tutorials locally
 
-Contributing tutorial material
-------------------------------
+Clone this repository with `git` or download an archive of the repository from
+GitHub. You will need to have [Jupyter notebook](http://jupyter.org/) and IPython
+installed. Then install the `requirements.txt` that are specified in the folder
+containing the specific `.ipynb` tutorial you wish to run. For example, to run the
+`FITS-cubes.ipynb` tutorial, first install:
+
+    python -m pip install -r FITS-cubes/requirements.txt
+
+
+## Contributing tutorial material
 
 We are always interested in incorporating new tutorials into Learn Astropy and
-the Astropy Tutorials series. We welcome tutorials covering astro-relevant topics and they do not
-necessarily need to use the Astropy package in order to be hosted or indexed here.
+the Astropy Tutorials series. We welcome tutorials covering astro-relevant topics; they
+do not need to use the Astropy package in order to be hosted or indexed here.
 If you have astronomy tutorials that you would like to contribute to this repository,
 or if you have a separate tutorial series that you would like indexed by the
 Learn Astropy website, please see the [Contributing

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Jupyter notebook as with any other notebook files.
 You can also get started with a remote environment to run the tutorial notebooks
 in your browser using [Binder](http://mybinder.org)
 
-[![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jeffjennings/astropy-tutorials/binder_build?filepath=tutorials)
+[![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/astropy/astropy-tutorials/main?filepath=tutorials)
 
 
 Contributing tutorial material

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Jupyter notebook as with any other notebook files.
 You can also get started with a remote environment to run the tutorial notebooks
 in your browser using [Binder](http://mybinder.org)
 
-[![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/astropy/astropy-tutorials/main?filepath=tutorials)
+[![Binder](http://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jeffjennings/astropy-tutorials/binder_build?filepath=tutorials)
 
 
 Contributing tutorial material

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,15 @@
+astropy
+astroquery>=0.4.8.dev9474  # 2024-09-24 pinned for Gaia column capitalization issue
+dask
+dust_extinction
+gala
+IPython
+matplotlib
+numpy
+pillow
+pvextractor
+radio_beam
+reproject
+scipy
+spectral_cube @ git+https://github.com/radio-astro-tools/spectral-cube  # as of: 2024-10-10 for issue with 'distutils'
+synphot

--- a/tutorials/plot-catalog/plot-catalog.ipynb
+++ b/tutorials/plot-catalog/plot-catalog.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
+    "import numpyxx as np\n",
     "\n",
     "# Set up matplotlib\n",
     "import matplotlib.pyplot as plt\n",

--- a/tutorials/plot-catalog/plot-catalog.ipynb
+++ b/tutorials/plot-catalog/plot-catalog.ipynb
@@ -38,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpyxx as np\n",
+    "import numpy as np\n",
     "\n",
     "# Set up matplotlib\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
After removing the global `requirements.txt` in #606, the Binder build broke because it expects that file. In general it expects a single requirements file for all notebooks (see [here](https://stackoverflow.com/questions/59266239/github-binder-requirements-txt); for details of how to specify requirements, see [here](https://mybinder.readthedocs.io/en/latest/using/config_files.html#config-files)).

This PR adds `binder/requirements.txt` to the top-level directory, which Binder uses to successfully build. This single requirements file currently works for all notebooks. If in the future individual notebooks need packages installed with versions that differ from those in `binder/requirements.txt`, execution of those notebooks in Binder will fail.

PR also updates text in the README. 

Closes https://github.com/astropy/astropy-tutorials/issues/615
Closes https://github.com/astropy/astropy-tutorials/issues/616
Closes https://github.com/astropy/astropy-tutorials/issues/535

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.