### PR TITLE
Unpin tutorial dependency

### DIFF
--- a/tutorials/spectral-cube-reprojection/requirements.txt
+++ b/tutorials/spectral-cube-reprojection/requirements.txt
@@ -1,6 +1,6 @@
 astropy
 dask
-numpy==1.26.4 # pinned on 09-27-24; can remove pin when https://github.com/radio-astro-tools/spectral-cube/pull/917 is merged
+numpy
 radio_beam
 reproject
 spectral_cube @ git+https://github.com/radio-astro-tools/spectral-cube  # as of: 2024-10-10 for issue with 'distutils'


### PR DESCRIPTION
The `spectral-cube-reprojection` tutorial no longer needs a pin `<2.0` numpy dependency after upstream compatability update in `spectral-cube`.

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.
