### PR TITLE
Escape latex escape sequences in color-excess.ipynb

### DIFF
--- a/tutorials/color-excess/color-excess.ipynb
+++ b/tutorials/color-excess/color-excess.ipynb
@@ -164,8 +164,8 @@
     "        ext = model(Rv=R)\n",
     "        plt.plot(1/wav, ext(wav), label=model.name+' R='+str(R))\n",
     "        \n",
-    "plt.xlabel('$\\lambda^{-1}$ ($\\mu$m$^{-1}$)')\n",
-    "plt.ylabel('A($\\lambda$) / A(V)')\n",
+    "plt.xlabel(r'$\\lambda^{-1}$ ($\\mu$m$^{-1}$)')\n",
+    "plt.ylabel(r'A($\\lambda$) / A(V)')\n",
     "plt.legend(loc='best')\n",
     "plt.title('Some Extinction Laws')\n",
     "plt.show()"

--- a/tutorials/color-excess/color-excess.ipynb
+++ b/tutorials/color-excess/color-excess.ipynb
@@ -632,8 +632,8 @@
     "# Plot the model extinction curve for comparison \n",
     "plt.plot(wav,Av*ext(wav)-Av,'--k')\n",
     "plt.ylim([-2,2])\n",
-    "plt.xlabel('$\\lambda$ (Angstrom)')\n",
-    "plt.ylabel('E($\\lambda$-V)')\n",
+    "plt.xlabel(r'$\\lambda$ (Angstrom)')\n",
+    "plt.ylabel(r'E($\\lambda$-V)')\n",
     "plt.title('Reddening of T=10,000K Background Source with Av=2')\n",
     "plt.show()  "
    ]


### PR DESCRIPTION
The rendered notebook shows syntax warnings because it can't parse \l which is intended for latex, and shouldn't be interpreted by python

- [x] Check the box to confirm that you are familiar with the [contributing guidelines](https://learn.astropy.org/contributing/how-to-contribute) and/or indicate (check the box) that you are familiar with our contributing workflow.
- [x] Confirm that any contributed tutorials contain a complete Introduction which includes an Author list, Learning Goals, Keywords, Companion Content (if applicable), and a Summary.
- [x] Check the box to confirm that you are familiar with the Astropy community [code of conduct](https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md) and you agree to follow the CoC.
